### PR TITLE
fix(workflow): Correct branch name for deployment trigger

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -3,7 +3,7 @@ name: Deploy Documentation
 on:
   push:
     branches:
-      - main
+      - master
 
 jobs:
   deploy:


### PR DESCRIPTION
## Summary
- Changes the trigger branch in the documentation deployment workflow from 'main' to 'master' to match the repository's default branch

## Changes
- Updated `.github/workflows/deploy-docs.yml` to trigger on pushes to `master` branch instead of `main`

This fix ensures the documentation deployment workflow will actually run when changes are pushed to the default branch.