### PR TITLE
fix(docs): Fix broken links and update documentation site

### DIFF
--- a/docs/docs/Principles/context-engineering.md
+++ b/docs/docs/Principles/context-engineering.md
@@ -1,0 +1,41 @@
+---
+sidebar_position: 2
+---
+
+# Context Engineering
+
+Large language models have a fundamental limitation: a finite context window. Meanwhile, modern software projects are vast, complex, and spread across thousands of files. You can't simply paste an entire codebase into a prompt and expect a good result. So, how do you provide an AI with the right information to perform a meaningful engineering task?
+
+This is the core problem that Context Engineering solves. Instead of flooding the AI with irrelevant data or providing too little information for it to be effective, Context Engineering is the discipline of designing, managing, and delivering the precise, relevant context an AI needs to perform a specific task. It is the foundational practice upon which the Simone framework is built.
+
+## Core Principles of Context Engineering
+
+Simone is built on several key principles of context engineering:
+
+### 1. Structured Knowledge
+
+Instead of treating project information as a single, monolithic block, it is organized into logical, queryable components. This includes high-level vision, architectural documentation, specific requirements, and the breakdown of work into tasks. This separation allows for the precise retrieval of information relevant to any given task.
+
+### 2. Layered Context
+
+The AI is provided with layers of context, moving from the general to the specific. When executing a task, it can be given access to the overarching project goals, relevant architectural patterns, and the fine-grained details of the specific work item, ensuring it has a multi-faceted understanding of its objective.
+
+### 3. Just-in-Time Context
+
+Information is provided precisely when needed. By tying context retrieval to specific commands or prompts, we ensure the information provided is always relevant to the job at hand. This minimizes noise and maximizes the signal of the information presented to the model.
+
+### 4. AI-Friendly Format
+
+All project artifacts are stored in simple, machine-readable formats (primarily Markdown and YAML). This design choice makes it effortless for the AI to parse, understand, and reason about the project's state.
+
+## Context Engineering in Practice
+
+Simone provides concrete mechanisms to implement these principles, ensuring that the AI always operates with the most relevant and up-to-date information.
+
+*   **Structured Knowledge Base:** At its core, Simone maintains a structured repository of all project-related information. This includes everything from high-level architectural guides to specific task requirements, ensuring all context is organized and accessible.
+
+*   **Intelligent Context Loading:** Commands in both the legacy system (e.g., `/simone:do_task`) and the MCP server (e.g., `/do_task`) act as powerful, context-aware triggers. When executed, they intelligently gather and load the precise information required for the specific task at hand.
+
+*   **On-Demand Context for Fresh Sessions:** This approach enables a powerful workflow where a developer can start a fresh session with a minimal context. By executing a single command, such as one to begin work on an open issue, Simone instantly assembles and provides all the necessary background, specifications, and file context. This allows the AI to focus directly on the task, avoiding the noise of irrelevant information and preventing it from becoming overwhelmed.
+
+By mastering context engineering, Simone transforms the AI from a simple code generator into a true engineering partner that understands the *why* behind the *what*.

--- a/docs/docs/Principles/specs-driven-development.md
+++ b/docs/docs/Principles/specs-driven-development.md
@@ -1,0 +1,43 @@
+---
+sidebar_position: 3
+---
+
+# Specs-Driven Development
+
+Imagine building a house without a blueprint. The foundation might be wrong, the walls might not align, and the final result would be chaotic and unpredictable. In software, writing code without a clear plan can lead to the same problems.
+
+**Specs-Driven Development (SDD)** is the practice of creating that blueprint before any code is written. It is a methodology where a formal, detailed **specification** (or "spec") is the central driver for the entire development lifecycle. This spec acts as the single source of truth for both the human developer and, crucially, the AI partner.
+
+:::note What Problem Does SDD Solve for AI?
+Large Language Models are incredibly powerful, but they lack human intuition and deep business context. If you give an AI a vague request, you'll get a vague or incorrect result.
+
+Specs-Driven Development bridges this gap. By providing the AI with a clear, structured, and unambiguous spec, you transform it from an unpredictable generator into a reliable engineering partner. The developer's role evolves from a **coder** to an **architect**—designing the blueprint that the AI can then execute with precision.
+:::
+
+## The Core Workflow in Simone
+
+In the Simone ecosystem, Specs-Driven Development follows a clear, three-step process that emphasizes planning and precision.
+
+### 1. Define the Spec
+The developer's first and most important job is to analyze a problem and create a detailed task specification. This isn't a quick note; it's a formal piece of documentation that leaves no room for ambiguity.
+
+A good spec should include:
+- **A Clear Goal:** What is the user story or objective?
+- **Acceptance Criteria:** How do we know when the task is done and correct?
+- **Constraints & Edge Cases:** What are the boundaries and potential pitfalls?
+- **Implementation Notes:** Are there specific patterns, libraries, or functions that must be used?
+
+### 2. AI Implementation
+With a clear spec in hand, the developer delegates the implementation to the AI using a simple command, like `/do_task`. Simone loads the spec as the primary context, allowing the AI to focus entirely on translating the well-defined requirements into code.
+
+### 3. Review and Refine
+The developer reviews the AI-generated code against the spec. If the output is incorrect or incomplete, the first instinct shouldn't be to fix the code directly. Instead, the developer should ask: **"Is the spec clear enough?"**
+
+By refining the spec and having the AI regenerate the code, the spec remains the true source of truth, ensuring that the documentation and implementation never drift apart.
+
+:::tip The Benefits of a Spec-First Approach
+- **Predictable AI:** Dramatically improves the reliability and consistency of the AI's output.
+- **Enhanced Developer Focus:** Frees developers from tedious coding to focus on higher-level architecture and problem-solving.
+- **Living Documentation:** Your spec library becomes a rich, detailed, and always up-to-date history of your project's functionality.
+- **Superior Testability:** Clear acceptance criteria in a spec are the perfect foundation for writing robust unit and integration tests.
+:::

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -1,0 +1,43 @@
+/**
+ * Any CSS included here will be global.
+ *
+ * Such CSS is imported from `src/pages/_app.js`.
+ */
+
+/* You can override the default Infima variables here. */
+:root {
+  --ifm-color-primary: #855ebb;
+  --ifm-color-primary-dark: #7653a8;
+  --ifm-color-primary-darker: #6c4c99;
+  --ifm-color-primary-darkest: #593f7d;
+  --ifm-color-primary-light: #9469d0;
+  --ifm-color-primary-lighter: #9e76d8;
+  --ifm-color-primary-lightest: #b292e4;
+}
+
+/* For readability concerns, you should choose a lighter palette in dark mode. */
+[data-theme='dark'] {
+  --ifm-color-primary: #9e76d8;
+  --ifm-color-primary-dark: #8f67c7;
+  --ifm-color-primary-darker: #855ebb;
+  --ifm-color-primary-darkest: #6c4c99;
+  --ifm-color-primary-light: #ad85e9;
+  --ifm-color-primary-lighter: #b292e4;
+  --ifm-color-primary-lightest: #c6aef0;
+}
+
+.header-github-link:hover {
+  opacity: 0.6;
+}
+
+.header-github-link:before {
+  content: '';
+  width: 24px;
+  height: 24px;
+  display: flex;
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12'/%3E%3C/svg%3E");
+}
+
+[data-theme='dark'] .header-github-link:before {
+    background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill='white' d='M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12'/%3E%3C/svg%3E");
+}

--- a/documentation/introduction.md
+++ b/documentation/introduction.md
@@ -80,5 +80,5 @@ Instead of expecting the AI to retain all project knowledge across long interact
 
 Ready to enhance your AI-assisted development? Choose your path:
 
-*   [**Legacy System Installation**](/docs/getting-started/legacy-installation) - Start with the stable, production-ready version.
-*   [**MCP Server Installation**](/docs/getting-started/mcp-installation) - Explore the cutting-edge, in-development future of Simone.
+*   [**Legacy System Installation**](/getting-started/legacy-installation) - Start with the stable, production-ready version.
+*   [**MCP Server Installation**](/getting-started/mcp-installation) - Explore the cutting-edge, in-development future of Simone.

--- a/documentation/introduction.md
+++ b/documentation/introduction.md
@@ -37,19 +37,19 @@ Instead of expecting the AI to retain all project knowledge across long interact
     title="File-Based Context"
     description="Organizes project knowledge in a structured directory of Markdown files for transparent context management."
     icon="📁"
-    to="/docs/legacy-system/overview"
+    to="/legacy-system/overview"
   />
   <FeatureCard
     title="AI-Guided Commands"
     description="Utilizes human-readable Markdown files as detailed instructions for AI agents to execute complex tasks."
     icon="🤖"
-    to="/docs/legacy-system/command-reference/initialize"
+    to="/legacy-system/command-reference/initialize"
   />
   <FeatureCard
     title="Iterative Workflow"
     description="Supports a structured development cycle from planning milestones to executing and committing individual tasks."
     icon="🔄"
-    to="/docs/legacy-system/workflow"
+    to="/legacy-system/workflow"
   />
 </div>
 
@@ -60,19 +60,19 @@ Instead of expecting the AI to retain all project knowledge across long interact
     title="Protocol-Driven Interaction"
     description="Communicates with AI agents via the Model Context Protocol (MCP) for robust and standardized interactions."
     icon="⚡"
-    to="/docs/mcp-server/overview"
+    to="/mcp-server/overview"
   />
   <FeatureCard
     title="Activity Logging"
     description="Features a built-in SQLite database to persistently log all AI-assisted development activities for analysis."
     icon="📊"
-    to="/docs/mcp-server/workflow"
+    to="/mcp-server/workflow"
   />
   <FeatureCard
     title="Dynamic Prompts"
     description="Leverages Handlebars templating to create highly configurable and context-aware prompts for AI agents."
     icon="✨"
-    to="/docs/mcp-server/prompt-reference"
+    to="/mcp-server/prompt-reference"
   />
 </div>
 

--- a/legacy/SIMONE_COMMANDS_GUIDE.md
+++ b/legacy/SIMONE_COMMANDS_GUIDE.md
@@ -9,7 +9,6 @@ Simone commands follow the pattern: `/simone:<command_name> [arguments]`
 ## Setup & Context Commands
 
 ### 🚀 `/simone:initialize`
-
 **Purpose**: Initialize Simone for a new or existing project
 
 **Usage**:
@@ -32,7 +31,6 @@ Simone commands follow the pattern: `/simone:<command_name> [arguments]`
 ---
 
 ### 🧠 `/simone:prime`
-
 **Purpose**: Load project context at the start of a coding session
 
 **Usage**:
@@ -53,7 +51,6 @@ Simone commands follow the pattern: `/simone:<command_name> [arguments]`
 ## Planning Commands
 
 ### 📅 `/simone:create_sprints_from_milestone`
-
 **Purpose**: Break down a milestone into manageable sprints
 
 **Usage**:
@@ -74,7 +71,6 @@ Simone commands follow the pattern: `/simone:<command_name> [arguments]`
 ---
 
 ### 📋 `/simone:create_sprint_tasks`
-
 **Purpose**: Create detailed task breakdowns for a sprint
 
 **Usage**:
@@ -97,7 +93,6 @@ Simone commands follow the pattern: `/simone:<command_name> [arguments]`
 ---
 
 ### ✏️ `/simone:create_general_task`
-
 **Purpose**: Create standalone tasks not tied to sprints
 
 **Usage**:
@@ -118,7 +113,6 @@ Simone commands follow the pattern: `/simone:<command_name> [arguments]`
 ## Development Commands
 
 ### 💻 `/simone:do_task`
-
 **Purpose**: Execute a specific task
 
 **Usage**:
@@ -144,7 +138,6 @@ Simone commands follow the pattern: `/simone:<command_name> [arguments]`
 ---
 
 ### 📝 `/simone:commit`
-
 **Purpose**: Create well-structured git commits
 
 **Usage**:
@@ -173,7 +166,6 @@ Simone commands follow the pattern: `/simone:<command_name> [arguments]`
 ---
 
 ### 🧪 `/simone:test`
-
 **Purpose**: Run tests and fix common issues
 
 **Usage**:
@@ -198,7 +190,6 @@ Simone commands follow the pattern: `/simone:<command_name> [arguments]`
 ## Review Commands
 
 ### 🔍 `/simone:code_review`
-
 **Purpose**: Review code against specifications
 
 **Usage**:
@@ -224,7 +215,6 @@ Simone commands follow the pattern: `/simone:<command_name> [arguments]`
 ---
 
 ### 📊 `/simone:project_review`
-
 **Purpose**: Comprehensive project health check
 
 **Usage**:
@@ -246,7 +236,6 @@ Simone commands follow the pattern: `/simone:<command_name> [arguments]`
 ---
 
 ### 🧪 `/simone:testing_review`
-
 **Purpose**: Analyze test coverage and quality
 
 **Usage**:
@@ -267,7 +256,6 @@ Simone commands follow the pattern: `/simone:<command_name> [arguments]`
 ---
 
 ### 💬 `/simone:discuss_review`
-
 **Purpose**: Technical discussion about review findings
 
 **Usage**:
@@ -289,7 +277,6 @@ Simone commands follow the pattern: `/simone:<command_name> [arguments]`
 ---
 
 ### 📊 `/simone:mermaid`
-
 **Purpose**: Create and maintain architecture diagrams
 
 **Usage**:
@@ -321,7 +308,6 @@ Simone commands follow the pattern: `/simone:<command_name> [arguments]`
 ## Automation Commands
 
 ### 🚀 `/simone:yolo`
-
 **Purpose**: Autonomous task execution
 
 **Usage**:


### PR DESCRIPTION
## Summary
This PR fixes broken navigation links in the documentation site and includes additional content improvements and theme updates.

## Changes
- **Fixed broken links**: Removed `/docs` prefix from all navigation links in the introduction page
- **Updated command syntax**: Replaced legacy `/project:simone:` with correct `/simone:` format throughout documentation
- **Added new content**: Created high-level pages for "Context Engineering" and "Specs-Driven Development"
- **Enhanced UI**: Updated site theme with lavender accent colors, new logo, and cleaner header design
- **Added announcement bar**: "Work in Progress" notice to inform visitors about ongoing documentation updates

## Implementation Notes
The broken links were caused by the `/docs` prefix being incorrectly included in the navigation URLs. The documentation framework automatically handles the base path, so these prefixes were causing 404 errors in production.

The theme updates provide better visual consistency and a more professional appearance for the documentation site.

## Testing
- [x] Verified all navigation links work correctly without `/docs` prefix
- [x] Confirmed command syntax updates are accurate
- [x] Tested site theme changes across different screen sizes
- [x] Validated that the announcement bar displays properly

## Screenshots
Due to the nature of these changes, the visual updates are best viewed in the deployed documentation site after merging.