### PR TITLE
fix(workflow): Add write permissions for GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: write
+
 jobs:
   deploy:
     name: Deploy to GitHub Pages


### PR DESCRIPTION
## Summary
- Add `contents: write` permission to deploy-docs.yml workflow
- Fixes the "Permission denied" error when pushing to gh-pages branch

## Context
The documentation build was completing successfully, but the deployment step was failing with:
```
remote: Permission to Helmi/claude-simone.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/Helmi/claude-simone.git/': The requested URL returned error: 403
```

This is a common issue that occurs when the workflow doesn't have write permissions to push to the repository.

## Test plan
- [x] Workflow syntax is valid
- [ ] After merge, the next push to master should successfully deploy to GitHub Pages