### PR TITLE
fix(docs): Update baseUrl for GitHub Pages project site

### DIFF
--- a/documentation/docusaurus.config.ts
+++ b/documentation/docusaurus.config.ts
@@ -18,7 +18,7 @@ const config: Config = {
   url: 'https://helmi.github.io',
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
-  baseUrl: '/',
+  baseUrl: '/claude-simone/',
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.


### PR DESCRIPTION
## Summary
- Updates `baseUrl` from `/` to `/claude-simone/` in docusaurus.config.ts
- Fixes the "Your Docusaurus site did not load properly" error on GitHub Pages

## Context
GitHub Pages serves project sites at `/<projectName>/` path. The documentation was built with `baseUrl: '/'` which causes all assets and routing to fail when served at `/claude-simone/`.

## Test plan
- [x] Configuration syntax is valid
- [ ] After merge and deployment, the site should load properly at https://helmi.github.io/claude-simone/