### PR TITLE
fix(docs): Resolve duplicate routes warning at root path

### DIFF
--- a/documentation/introduction.md
+++ b/documentation/introduction.md
@@ -1,6 +1,5 @@
 ---
 sidebar_position: 1
-slug: /
 ---
 
 import FeatureCard from '@site/src/components/FeatureCard';

--- a/hello-simone/package.json
+++ b/hello-simone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hello-simone",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Installer for Simone - AI-powered project management system",
   "type": "module",
   "bin": {

--- a/versions/versions.json
+++ b/versions/versions.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./versions.schema.json",
   "description": "Central version tracking for all Simone components",
-  "updated": "2025-07-13",
+  "updated": "2025-07-22",
   "components": {
     "legacy": {
       "name": "Simone Legacy",
@@ -13,7 +13,7 @@
     },
     "hello-simone": {
       "name": "hello-simone",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "type": "npm",
       "tagPrefix": "hello/v",
       "path": "./hello-simone",


### PR DESCRIPTION
## Summary
Closes #24

This PR fixes the duplicate routes warning that was occurring during the documentation build process.

## Changes
- Removed `slug: /` from `introduction.md` frontmatter
- The introduction page still serves as the homepage through Docusaurus's default routing behavior with `routeBasePath: '/'`

## Root Cause
The duplicate route warning occurred because both the Docusaurus configuration (`routeBasePath: '/'`) and the introduction.md file (`slug: /`) were trying to claim the root path. By removing the explicit slug directive, we let Docusaurus handle the routing automatically.

## Testing
- ✅ Documentation build completes without warnings
- ✅ Homepage still displays the introduction content at `/`
- ✅ All other documentation routes continue to work correctly

## Trade-offs
This is a minimal fix that leverages Docusaurus's default behavior rather than adding complex configuration. The introduction page automatically becomes the homepage as it's the first document with `sidebar_position: 1`.