### PR TITLE
fix(mcp-server): pass features config to Handlebars template context

### DIFF
--- a/mcp-server/src/templates/handler.ts
+++ b/mcp-server/src/templates/handler.ts
@@ -57,6 +57,7 @@ export class PromptHandler {
       context['contexts'] = projectConfig.contexts;
       context['shared'] = projectConfig.shared;
       context['github'] = projectConfig.github;
+      context['features'] = projectConfig.features;
     }
 
     // Add extended project context


### PR DESCRIPTION
## Summary

- Fixes missing features configuration in Handlebars template context
- Adds one line to pass `projectConfig.features` to the template context
- Enables feature conditionals like `{{#if features.git_worktree.enabled}}` to work properly

Closes #44

## Changes Made

- Modified `mcp-server/src/templates/handler.ts` to include features configuration in the template context
- Added `context['features'] = projectConfig.features;` after the github configuration line

## Testing

- The fix enables templates to access features configuration via Handlebars conditionals
- Git worktree instructions will now appear in work_issue prompt when `features.git_worktree.enabled` is true
- PR review wait instructions will appear when `features.pr_review_wait.enabled` is true

## Trade-offs

None - this is a simple bug fix that adds missing functionality without any negative impacts.

## Test plan

- [ ] Verify that templates can access features configuration
- [ ] Confirm git_worktree instructions appear when enabled
- [ ] Confirm pr_review_wait instructions appear when enabled
- [ ] Ensure no regression in existing functionality