### PR TITLE
feat(hello-simone): update installer to use simone-mcp@latest with --yes flag

### DIFF
--- a/documentation/mcp-installation.md
+++ b/documentation/mcp-installation.md
@@ -29,7 +29,7 @@ Create a `.mcp.json` file in the root of your project with the following content
   "mcpServers": {
     "simone": {
       "command": "npx",
-      "args": ["simone-mcp"],
+      "args": ["--yes", "simone-mcp@latest"],
       "env": {
         "PROJECT_PATH": "/path/to/your/project"
       }
@@ -40,8 +40,8 @@ Create a `.mcp.json` file in the root of your project with the following content
 
 ### Key Configuration Parameters:
 
-*   **`command`**: The command to execute the server. Using `npx` here ensures the latest version is run without manual updates.
-*   **`args`**: The arguments to pass to the command, typically the name of the MCP package.
+*   **`command`**: The command to execute the server. We use `npx` to run the package.
+*   **`args`**: The arguments to pass to the command. Using `--yes` skips confirmation prompts, and `@latest` ensures the latest version is fetched.
 *   **`env.PROJECT_PATH`**: This is a crucial environment variable. You **must** provide the absolute path to your project directory. This informs the Simone MCP server which project it is managing and provides the necessary root context.
 
 Once configured, your AI tool will be able to discover and utilize the prompts and tools exposed by the Simone MCP server.

--- a/hello-simone/install-mcp.js
+++ b/hello-simone/install-mcp.js
@@ -122,7 +122,7 @@ export async function installMCP(dryRun = false) {
     // Add simone configuration
     mcpConfig.mcpServers.simone = {
       command: "npx",
-      args: ["simone-mcp"],
+      args: ["--yes", "simone-mcp@latest"],
       env: {
         PROJECT_PATH: getPlatformProjectPath(),
       },

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -36,7 +36,7 @@ To manually configure, add this to your project's `.mcp.json`:
   "mcpServers": {
     "simone": {
       "command": "npx",
-      "args": ["simone-mcp"],
+      "args": ["--yes", "simone-mcp@latest"],
       "env": {
         "PROJECT_PATH": "/path/to/your/project"
       }


### PR DESCRIPTION
## Summary

- Updates hello-simone installer to configure .mcp.json with `["--yes", "simone-mcp@latest"]` args
- Ensures users always get the latest version of simone-mcp without npx confirmation prompts
- Updates all documentation examples to reflect the new configuration pattern

Closes #36

## Changes Made

1. **hello-simone/install-mcp.js**
   - Changed args array from `["simone-mcp"]` to `["--yes", "simone-mcp@latest"]` (line 125)

2. **documentation/mcp-installation.md**
   - Updated example configuration with new args array
   - Fixed misleading comment about npx version handling
   - Now accurately describes that `@latest` ensures the latest version is fetched

3. **mcp-server/README.md**
   - Updated example configuration to match new pattern

## Testing

- The changes ensure that new installations will always fetch the latest simone-mcp version
- The `--yes` flag prevents npx from showing confirmation prompts, making the experience smoother
- Existing installations continue to work (backward compatible)

## Trade-offs

- Slightly larger args array in configuration files
- Users with existing .mcp.json files will need to manually update to get the benefits (installer doesn't overwrite existing configs)

## Test plan

- [ ] Verify hello-simone generates correct .mcp.json with new args
- [ ] Test that npx with --yes flag skips confirmation prompts
- [ ] Confirm @latest fetches the latest version even with npm cache
- [ ] Ensure documentation examples are consistent across all files