### PR TITLE
Release: simone-mcp@0.2.0 and hello-simone@0.6.2

### DIFF
--- a/hello-simone/CHANGELOG.md
+++ b/hello-simone/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to hello-simone will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.2] - 2025-07-23
+
+### Changed
+
+- Updated MCP installer to use `simone-mcp@latest` with `--yes` flag for automatic updates
+- Installer now always fetches the latest version of simone-mcp without npm prompts
+
 ## [0.6.1] - 2025-07-22
 
 ### Fixed

--- a/hello-simone/package.json
+++ b/hello-simone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hello-simone",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Installer for Simone - AI-powered project management system",
   "type": "module",
   "bin": {

--- a/mcp-server/CHANGELOG.md
+++ b/mcp-server/CHANGELOG.md
@@ -9,6 +9,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2025-07-23
+
+### Added
+
+- PR review wait feature that automatically monitors and reports pull request status
+- Configurable optional features system allowing users to enable/disable functionality
+- Better error handling and retry logic for GitHub API operations
+
+### Changed
+
+- Enhanced work_issue prompt with automatic git synchronization and improved flexibility
+- Improved template context handling for more reliable prompt rendering
+
+### Fixed
+
+- SQLite database lock errors by implementing proper connection sharing
+- Features configuration not being passed to Handlebars templates correctly
+- GitHub label fetching in create_issue prompt now retrieves actual repository labels
+
+### Removed
+
+- Git worktree feature due to incompatibility with Claude's session isolation model
+
 ## [0.1.0] - 2025-07-21
 
 ### Added

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simone-mcp",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "MCP server for Simone - AI-powered project and task management",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Release Summary

Preparing releases for both packages:

### simone-mcp: 0.1.0 → 0.2.0
- Added PR review wait feature
- Added configurable optional features system
- Fixed SQLite database lock errors
- Improved work_issue prompt
- Removed git worktree feature

### hello-simone: 0.6.1 → 0.6.2
- Updated installer to use `simone-mcp@latest` with `--yes` flag

## Tasks
- [x] Update version numbers
- [x] Update CHANGELOG files
- [ ] Merge PR
- [ ] Create GitHub releases
- [ ] Publish to npm