### PR TITLE
fix(hello-simone): correct template download issues

### DIFF
--- a/hello-simone/install-mcp.js
+++ b/hello-simone/install-mcp.js
@@ -166,8 +166,7 @@ export async function installMCP(dryRun = false) {
         const templates = [
           { name: 'project.yaml.template', target: 'project.yaml.template' },
           { name: 'constitution.md.template', target: 'constitution.md.template' },
-          { name: 'architecture.md.template', target: 'architecture.md.template' },
-          { name: 'CLAUDE.md.template', target: 'CLAUDE.md.template' }
+          { name: 'architecture.md.template', target: 'architecture.md.template' }
         ];
 
         let downloadedCount = 0;
@@ -187,7 +186,7 @@ export async function installMCP(dryRun = false) {
           }
 
           // Download template from GitHub
-          const templateUrl = `https://raw.githubusercontent.com/Helmi/claude-simone/main/mcp-server/templates/${template.name}`;
+          const templateUrl = `https://raw.githubusercontent.com/Helmi/claude-simone/master/mcp-server/templates/${template.name}`;
           
           try {
             const { stdout } = await execAsync(`curl -s -f "${templateUrl}"`);
@@ -215,7 +214,7 @@ export async function installMCP(dryRun = false) {
           spinner.warn(`Failed to download ${failedCount} template(s)`);
           console.log(chalk.yellow("\nSome templates could not be downloaded."));
           console.log(chalk.yellow("You can download them manually from:"));
-          console.log(chalk.cyan("https://github.com/Helmi/claude-simone/tree/main/mcp-server/templates"));
+          console.log(chalk.cyan("https://github.com/Helmi/claude-simone/tree/master/mcp-server/templates"));
           
           // Don't exit if some templates fail - user can continue with what downloaded
         }


### PR DESCRIPTION
## Summary

Fixes two issues preventing templates from downloading during MCP installation:

1. **Removed CLAUDE.md.template** - This file doesn't exist in the repository but was being requested by the installer
2. **Fixed branch name** - Changed GitHub URLs from 'main' to 'master' (the actual default branch)

## Problem

Users were seeing warnings during installation:
```
Warning: Could not download project.yaml.template
Warning: Could not download constitution.md.template
Warning: Could not download architecture.md.template
Warning: Could not download CLAUDE.md.template
```

## Solution

- Removed CLAUDE.md.template from the templates list
- Updated all GitHub URLs to use 'master' branch instead of 'main'
- Also updated the manual download URL in the error message

## Test Plan

After this fix, running `npx hello-simone --mcp` should:
- Successfully download the 3 existing template files
- Not attempt to download CLAUDE.md.template
- Show no warnings for template downloads (unless there's a network issue)