### PR TITLE
Release: hello-simone v0.6.3

### DIFF
--- a/hello-simone/CHANGELOG.md
+++ b/hello-simone/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to hello-simone will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.3] - 2025-07-23
+
+### Fixed
+
+- Fixed template download failures by correcting GitHub URLs from 'main' to 'master' branch
+- Removed non-existent CLAUDE.md.template from download list
+- Updated manual download URL in error messages
+
 ## [0.6.2] - 2025-07-23
 
 ### Changed

--- a/hello-simone/package.json
+++ b/hello-simone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hello-simone",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Installer for Simone - AI-powered project management system",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Release Summary

Patch release to fix template download issues during MCP installation.

### hello-simone: 0.6.2 → 0.6.3

#### Fixed
- Template downloads failing with 404 errors due to incorrect branch name
- Removed attempt to download non-existent CLAUDE.md.template
- Updated manual download URL in error messages

## Tasks
- [x] Update version to 0.6.3
- [x] Update CHANGELOG
- [ ] Merge PR
- [ ] Create GitHub release
- [ ] Publish to npm

## User Impact
Users will no longer see template download warnings when running `npx hello-simone --mcp`.