### PR TITLE
Add optional GitHub Projects integration to Simone MCP server

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,6 +36,7 @@ jobs:
         uses: anthropics/claude-code-action@beta
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
           # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
           # model: "claude-opus-4-20250514"

--- a/mcp-server/TESTING.md
+++ b/mcp-server/TESTING.md
@@ -1,0 +1,253 @@
+# Testing Documentation for Simone MCP Server
+
+## Overview
+
+The Simone MCP Server uses a comprehensive testing strategy to ensure reliability and maintainability. The test suite is built with Vitest and achieves high code coverage across all modules.
+
+## Test Structure
+
+```
+src/
+├── __tests__/
+│   ├── fixtures/          # Reusable test data
+│   │   ├── activity-log.ts
+│   │   ├── config.ts
+│   │   ├── index.ts
+│   │   └── prompts.ts
+│   ├── utils/             # Test utilities
+│   │   ├── mcp-transport-mock.ts
+│   │   ├── test-database.ts
+│   │   └── test-fixtures.ts
+│   └── server.integration.test.ts
+├── config/__tests__/
+│   └── loader.test.ts
+├── templates/__tests__/
+│   ├── context.test.ts
+│   ├── handler.test.ts
+│   ├── helpers.test.ts
+│   └── loader.test.ts
+└── tools/
+    ├── __tests__/
+    │   ├── database.test.ts
+    │   └── index.test.ts
+    └── activity-logger/__tests__/
+        ├── activity-types.test.ts
+        ├── index.test.ts
+        ├── path-normalizer.test.ts
+        └── tool.test.ts
+```
+
+## Testing Stack
+
+- **Test Framework**: Vitest 3.2.4
+- **Coverage**: @vitest/coverage-v8
+- **Database Testing**: better-sqlite3 with in-memory databases
+- **Mocking**: Vitest's built-in mocking capabilities
+
+## Running Tests
+
+```bash
+# Run all tests
+pnpm test
+
+# Run tests in watch mode
+pnpm test:watch
+
+# Run tests with coverage
+pnpm test:coverage
+
+# Run specific test file
+pnpm test src/config/__tests__/loader.test.ts
+```
+
+## Test Categories
+
+### 1. Unit Tests
+
+Unit tests cover individual modules in isolation:
+
+- **Configuration Loader**: Tests for loading and merging YAML configurations
+- **Template System**: Tests for Handlebars template compilation and rendering
+- **Activity Logger**: Tests for activity tracking and database operations
+- **Tool Handlers**: Tests for MCP tool registration and execution
+- **Utilities**: Tests for path normalization, context detection, etc.
+
+### 2. Integration Tests
+
+Integration tests verify component interactions:
+
+- **MCP Server**: Tests the full server lifecycle, request handling, and graceful shutdown
+- **Database Integration**: Tests schema initialization and data persistence
+- **Template Loading**: Tests the complete prompt loading and rendering pipeline
+
+### 3. Test Utilities
+
+#### Mock Transport (`mcp-transport-mock.ts`)
+
+Simulates MCP transport for testing server communication:
+
+```typescript
+const transport = new MockTransport();
+transport.simulateMessage({
+  jsonrpc: '2.0',
+  method: 'tools/call',
+  params: { name: 'log_activity', arguments: {...} }
+});
+```
+
+#### Test Database (`test-database.ts`)
+
+Creates in-memory SQLite databases for testing:
+
+```typescript
+const db = createTestDatabase();
+// Includes full schema initialization
+// Supports data seeding for tests
+```
+
+#### Fixtures
+
+Reusable test data organized by domain:
+
+- **Prompts**: Various YAML prompt configurations
+- **Config**: Configuration file samples
+- **Activity Log**: Sample activity data
+- **MCP Messages**: Mock request/response patterns
+
+## Testing Patterns
+
+### 1. Database Testing
+
+```typescript
+describe('DatabaseConnection', () => {
+  let db: Database.Database;
+  
+  beforeEach(() => {
+    db = createTestDatabase();
+  });
+  
+  afterEach(() => {
+    if (db?.open) db.close();
+  });
+  
+  it('should handle transactions', () => {
+    // Test transactional operations
+  });
+});
+```
+
+### 2. Async Operations
+
+```typescript
+it('should handle async template loading', async () => {
+  const loader = new TemplateLoader(projectPath);
+  const prompt = await loader.loadPrompt('test-prompt');
+  expect(prompt).toBeDefined();
+});
+```
+
+### 3. Error Handling
+
+```typescript
+it('should handle missing prompts gracefully', async () => {
+  const messages = await handler.getPromptMessages('non-existent', {});
+  expect(messages[0].content.text).toContain('error');
+});
+```
+
+### 4. Mocking File System
+
+```typescript
+vi.mock('fs/promises', () => ({
+  readFile: vi.fn().mockResolvedValue('mocked content'),
+  readdir: vi.fn().mockResolvedValue(['file1.yaml', 'file2.yaml']),
+  stat: vi.fn().mockResolvedValue({ mtimeMs: Date.now() })
+}));
+```
+
+## Coverage Configuration
+
+The project targets 80% code coverage with specific thresholds:
+
+```typescript
+// vitest.config.ts
+coverage: {
+  provider: 'v8',
+  reporter: ['text', 'html', 'lcov'],
+  thresholds: {
+    lines: 80,
+    functions: 80,
+    branches: 70,
+    statements: 80
+  }
+}
+```
+
+## Best Practices
+
+1. **Test Isolation**: Each test should be independent and not rely on execution order
+2. **Descriptive Names**: Use clear, descriptive test names that explain what is being tested
+3. **Arrange-Act-Assert**: Follow the AAA pattern for test structure
+4. **Mock External Dependencies**: Mock file system, network, and database operations when appropriate
+5. **Test Edge Cases**: Include tests for error conditions, empty inputs, and boundary values
+6. **Use Fixtures**: Leverage test fixtures for consistent test data
+7. **Clean Up**: Always clean up resources (close databases, restore mocks) in afterEach hooks
+
+## Common Testing Scenarios
+
+### Testing Prompt Loading
+
+```typescript
+it('should load and render prompt with arguments', async () => {
+  const handler = new PromptHandler(loader, projectPath);
+  const messages = await handler.getPromptMessages('test-prompt', {
+    arg1: 'value1',
+    arg2: 'value2'
+  });
+  
+  expect(messages).toHaveLength(1);
+  expect(messages[0].content.text).toContain('value1');
+});
+```
+
+### Testing Tool Execution
+
+```typescript
+it('should execute tool and return result', async () => {
+  const result = await handleToolCall(
+    'log_activity',
+    { activity: 'Test', tool_name: 'test' },
+    tools,
+    context
+  );
+  
+  expect(result.isError).toBeUndefined();
+  expect(result.content[0].text).toContain('success');
+});
+```
+
+### Testing Configuration Loading
+
+```typescript
+it('should merge context and shared configuration', () => {
+  const config = loader.loadConfig();
+  const context = loader.getContextConfig('backend');
+  
+  expect(context.tools.github.credentials.method).toBe('github-cli');
+});
+```
+
+## Debugging Tests
+
+1. **Run single test**: Use `.only` to focus on a specific test
+2. **Debug output**: Use `console.log` or Vitest's debug mode
+3. **Check mocks**: Verify mock calls with `expect(mockFn).toHaveBeenCalledWith(...)`
+4. **Inspect database**: Query test database directly in tests
+
+## Future Improvements
+
+1. **E2E Tests**: Add end-to-end tests with actual MCP client
+2. **Performance Tests**: Add benchmarks for critical paths
+3. **Snapshot Testing**: Use for template output verification
+4. **Property-Based Testing**: Add generative tests for edge cases
+5. **Visual Regression**: For any UI components

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -26,6 +26,7 @@
     "build": "tsup",
     "test": "vitest",
     "test:coverage": "vitest run --coverage",
+    "test:watch": "vitest watch",
     "lint": "eslint . --max-warnings 0",
     "format": "prettier --write \"src/**/*.{ts,tsx,js,jsx,json,md}\"",
     "format:check": "prettier --check \"src/**/*.{ts,tsx,js,jsx,json,md}\"",
@@ -67,13 +68,15 @@
     "@types/better-sqlite3": "^7.6.13",
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^24.0.13",
+    "@vitest/coverage-v8": "^3.2.4",
     "conventional-changelog-cli": "^5.0.0",
     "husky": "^9.1.7",
     "lint-staged": "^16.1.2",
     "rimraf": "^6.0.1",
     "tsup": "^8.5.0",
     "tsx": "^4.20.3",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "vitest": "^3.2.4"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.15.1",

--- a/mcp-server/pnpm-lock.yaml
+++ b/mcp-server/pnpm-lock.yaml
@@ -36,6 +36,9 @@ importers:
       '@types/node':
         specifier: ^24.0.13
         version: 24.0.13
+      '@vitest/coverage-v8':
+        specifier: ^3.2.4
+        version: 3.2.4(vitest@3.2.4(@types/node@24.0.13)(jiti@2.4.2)(tsx@4.20.3)(yaml@2.8.0))
       conventional-changelog-cli:
         specifier: ^5.0.0
         version: 5.0.0(conventional-commits-filter@5.0.0)
@@ -50,23 +53,47 @@ importers:
         version: 6.0.1
       tsup:
         specifier: ^8.5.0
-        version: 8.5.0(jiti@2.4.2)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0)
+        version: 8.5.0(jiti@2.4.2)(postcss@8.5.6)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0)
       tsx:
         specifier: ^4.20.3
         version: 4.20.3
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@24.0.13)(jiti@2.4.2)(tsx@4.20.3)(yaml@2.8.0)
 
 packages:
+
+  '@ampproject/remapping@2.3.0':
+    resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
+    engines: {node: '>=6.0.0'}
 
   '@babel/code-frame@7.27.1':
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-identifier@7.27.1':
     resolution: {integrity: sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.28.0':
+    resolution: {integrity: sha512-jVZGvOxOuNSsuQuLRTh13nU0AogFlw32w/MT+LV6D3sP5WdbW61E77RnkbaO2dUvmPAYrBDJXGn5gGS6tH4j8g==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/types@7.28.2':
+    resolution: {integrity: sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@commitlint/cli@19.8.1':
     resolution: {integrity: sha512-LXUdNIkspyxrlV6VDHWBmCZRtkEVRpBKxi2Gtw3J54cGWhLCTouVD/Q6ZSaSvd2YaDObWK8mDjrz3TIKtaQMAA==}
@@ -321,6 +348,10 @@ packages:
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
 
+  '@istanbuljs/schema@0.1.3':
+    resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
+    engines: {node: '>=8'}
+
   '@jridgewell/gen-mapping@0.3.12':
     resolution: {integrity: sha512-OuLGC46TjB5BbN1dH8JULVVZY4WTdkF7tV9Ys6wLL1rubZnCMstOhNHueU5bLCrnRuDhKPDM4g6sw4Bel5Gzqg==}
 
@@ -445,8 +476,14 @@ packages:
   '@types/better-sqlite3@7.6.13':
     resolution: {integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==}
 
+  '@types/chai@5.2.2':
+    resolution: {integrity: sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==}
+
   '@types/conventional-commits-parser@5.0.1':
     resolution: {integrity: sha512-7uz5EHdzz2TqoMfV7ee61Egf5y6NkcO4FB/1iCCQnbeiI1F3xzv3vK5dBCXUCLQgGYS+mUeigK1iKQzvED+QnQ==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
@@ -462,6 +499,44 @@ packages:
 
   '@types/semver@7.7.0':
     resolution: {integrity: sha512-k107IF4+Xr7UHjwDc7Cfd6PRQfbdkiRabXGRjo07b4WyPahFBZCZ1sE+BNxYIJPPg73UkfOsVOLwqVc/6ETrIA==}
+
+  '@vitest/coverage-v8@3.2.4':
+    resolution: {integrity: sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==}
+    peerDependencies:
+      '@vitest/browser': 3.2.4
+      vitest: 3.2.4
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
+  '@vitest/expect@3.2.4':
+    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+
+  '@vitest/mocker@3.2.4':
+    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@3.2.4':
+    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+
+  '@vitest/runner@3.2.4':
+    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
+
+  '@vitest/snapshot@3.2.4':
+    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
+
+  '@vitest/spy@3.2.4':
+    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+
+  '@vitest/utils@3.2.4':
+    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
   JSONStream@1.3.5:
     resolution: {integrity: sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==}
@@ -513,6 +588,13 @@ packages:
 
   array-ify@1.0.0:
     resolution: {integrity: sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  ast-v8-to-istanbul@0.3.3:
+    resolution: {integrity: sha512-MuXMrSLVVoA6sYN/6Hke18vMzrT4TZNbZIj/hvh0fnYFpO+/kFXcLIaiPwXXWaQUPg4yJD8fj+lfJ7/1EBconw==}
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -570,9 +652,17 @@ packages:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
 
+  chai@5.2.1:
+    resolution: {integrity: sha512-5nFxhUrX0PqtyogoYOA8IPswy5sZFTOsBFl/9bNsmDLgsxYTzSZQJDPppDnZPTQbzSEm0hqGjWPzRemQCYbD6A==}
+    engines: {node: '>=18'}
+
   chalk@5.4.1:
     resolution: {integrity: sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
+  check-error@2.1.1:
+    resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
+    engines: {node: '>= 16'}
 
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
@@ -759,6 +849,10 @@ packages:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
     engines: {node: '>=10'}
 
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
   deep-extend@0.6.0:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
     engines: {node: '>=4.0.0'}
@@ -820,6 +914,9 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
@@ -835,6 +932,9 @@ packages:
 
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
   etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
@@ -854,6 +954,10 @@ packages:
   expand-template@2.0.3:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
     engines: {node: '>=6'}
+
+  expect-type@1.2.2:
+    resolution: {integrity: sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==}
+    engines: {node: '>=12.0.0'}
 
   express-rate-limit@7.5.1:
     resolution: {integrity: sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==}
@@ -986,6 +1090,10 @@ packages:
     engines: {node: '>=0.4.7'}
     hasBin: true
 
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
   has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
     engines: {node: '>= 0.4'}
@@ -997,6 +1105,9 @@ packages:
   hosted-git-info@7.0.2:
     resolution: {integrity: sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==}
     engines: {node: ^16.14.0 || >=18.0.0}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
   http-errors@2.0.0:
     resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}
@@ -1072,6 +1183,22 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-lib-source-maps@5.0.6:
+    resolution: {integrity: sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.1.7:
+    resolution: {integrity: sha512-BewmUXImeuRk2YY0PVbxgKAysvhRPUQE0h5QRM++nVWyubKGV0l8qQ5op8+B2DOmwSe63Jivj0BjkPQVf8fP5g==}
+    engines: {node: '>=8'}
+
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
@@ -1089,6 +1216,9 @@ packages:
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
   js-yaml@4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
@@ -1165,6 +1295,9 @@ packages:
     resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
     engines: {node: '>=18'}
 
+  loupe@3.2.0:
+    resolution: {integrity: sha512-2NCfZcT5VGVNX9mSZIxLRkEAegDGBpuQZBy13desuHeVORmBDyAET4TkJr4SjqQy3A8JDofMN6LpkK8Xcm/dlw==}
+
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
@@ -1174,6 +1307,13 @@ packages:
 
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
+
+  magicast@0.3.5:
+    resolution: {integrity: sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -1245,6 +1385,11 @@ packages:
   nano-spawn@1.0.2:
     resolution: {integrity: sha512-21t+ozMQDAL/UGgQVBbZ/xXvNO10++ZPuTmKRO8k9V3AClVRht49ahtDjfY8l1q6nSHOrE5ASfthzH3ol6R/hg==}
     engines: {node: '>=20.17'}
+
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
 
   napi-build-utils@2.0.0:
     resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
@@ -1333,6 +1478,10 @@ packages:
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -1342,6 +1491,10 @@ packages:
 
   picomatch@4.0.2:
     resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
+    engines: {node: '>=12'}
+
+  picomatch@4.0.3:
+    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
 
   pidtree@0.6.0:
@@ -1377,6 +1530,10 @@ packages:
         optional: true
       yaml:
         optional: true
+
+  postcss@8.5.6:
+    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
+    engines: {node: ^10 || ^12 || >=14}
 
   prebuild-install@7.1.3:
     resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
@@ -1512,6 +1669,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -1529,6 +1689,10 @@ packages:
   slice-ansi@7.1.0:
     resolution: {integrity: sha512-bSiSngZ/jWeX93BqeIAbImyTbEihizcwNjFoRUIY/T1wWQsfsm2Vw1agPKylXvQTU7iASGdHhyqRlqQzfz+Htg==}
     engines: {node: '>=18'}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
 
   source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
@@ -1554,6 +1718,9 @@ packages:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   statuses@2.0.1:
     resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
     engines: {node: '>= 0.8'}
@@ -1561,6 +1728,9 @@ packages:
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
+
+  std-env@3.9.0:
+    resolution: {integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==}
 
   string-argv@0.3.2:
     resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
@@ -1593,10 +1763,17 @@ packages:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
     engines: {node: '>=0.10.0'}
 
+  strip-literal@3.0.0:
+    resolution: {integrity: sha512-TcccoMhJOM3OebGhSBEmp3UZ2SfDMZUEBdRA/9ynfLi8yYajyWX3JiXArcJt4Umh4vISpspkQIY8ZZoCqjbviA==}
+
   sucrase@3.35.0:
     resolution: {integrity: sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==}
     engines: {node: '>=16 || 14 >=14.17'}
     hasBin: true
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
 
   tar-fs@2.1.3:
     resolution: {integrity: sha512-090nwYJDmlhwFwEW3QQl+vaNnxsO2yVsd45eTKRBzSzu+hlb1w2K9inVq5b0ngXuLVqQ4ApvsUHHnu/zQNkWAg==}
@@ -1613,6 +1790,10 @@ packages:
     resolution: {integrity: sha512-bX655WZI/F7EoTDw9JvQURqAXiPHi8o8+yFxPF2lWYyz1aHnmMRuXWqL6YB6GmeO0o4DIYWHLgGNi/X64T+X4Q==}
     engines: {node: '>=14.18'}
 
+  test-exclude@7.0.1:
+    resolution: {integrity: sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==}
+    engines: {node: '>=18'}
+
   text-extensions@2.4.0:
     resolution: {integrity: sha512-te/NtwBwfiNRLf9Ijqx3T0nlqZiQ2XrrtBvu+cLL8ZRrGkO0NHTug8MYFKyoSrv/sHTaSKfilUkizV6XhxMJ3g==}
     engines: {node: '>=8'}
@@ -1627,6 +1808,9 @@ packages:
   through@2.3.8:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
 
@@ -1636,6 +1820,18 @@ packages:
   tinyglobby@0.2.14:
     resolution: {integrity: sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==}
     engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.3:
+    resolution: {integrity: sha512-t2T/WLB2WRgZ9EpE4jgPJ9w+i66UZfDc8wHh0xrwiRNN+UwH98GIJkTeZqX9rg0i0ptwzqW+uYeIF0T4F8LR7A==}
+    engines: {node: '>=14.0.0'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -1727,6 +1923,79 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
+  vite@7.0.6:
+    resolution: {integrity: sha512-MHFiOENNBd+Bd9uvc8GEsIzdkn1JxMmEeYX35tI3fv0sJBUTfW5tQsoaOwuY4KhBI09A3dUJ/DXf2yxPVPUceg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@3.2.4:
+    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.4
+      '@vitest/ui': 3.2.4
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   webidl-conversions@4.0.2:
     resolution: {integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==}
 
@@ -1736,6 +2005,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   wordwrap@1.0.0:
@@ -1787,13 +2061,31 @@ packages:
 
 snapshots:
 
+  '@ampproject/remapping@2.3.0':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.12
+      '@jridgewell/trace-mapping': 0.3.29
+
   '@babel/code-frame@7.27.1':
     dependencies:
       '@babel/helper-validator-identifier': 7.27.1
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
+  '@babel/helper-string-parser@7.27.1': {}
+
   '@babel/helper-validator-identifier@7.27.1': {}
+
+  '@babel/parser@7.28.0':
+    dependencies:
+      '@babel/types': 7.28.2
+
+  '@babel/types@7.28.2':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.27.1
+
+  '@bcoe/v8-coverage@1.0.2': {}
 
   '@commitlint/cli@19.8.1(@types/node@24.0.13)(typescript@5.8.3)':
     dependencies:
@@ -2008,6 +2300,8 @@ snapshots:
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
 
+  '@istanbuljs/schema@0.1.3': {}
+
   '@jridgewell/gen-mapping@0.3.12':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.4
@@ -2106,9 +2400,15 @@ snapshots:
     dependencies:
       '@types/node': 24.0.13
 
+  '@types/chai@5.2.2':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+
   '@types/conventional-commits-parser@5.0.1':
     dependencies:
       '@types/node': 24.0.13
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
 
@@ -2121,6 +2421,67 @@ snapshots:
   '@types/normalize-package-data@2.4.4': {}
 
   '@types/semver@7.7.0': {}
+
+  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/node@24.0.13)(jiti@2.4.2)(tsx@4.20.3)(yaml@2.8.0))':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@bcoe/v8-coverage': 1.0.2
+      ast-v8-to-istanbul: 0.3.3
+      debug: 4.4.1
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 5.0.6
+      istanbul-reports: 3.1.7
+      magic-string: 0.30.17
+      magicast: 0.3.5
+      std-env: 3.9.0
+      test-exclude: 7.0.1
+      tinyrainbow: 2.0.0
+      vitest: 3.2.4(@types/node@24.0.13)(jiti@2.4.2)(tsx@4.20.3)(yaml@2.8.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@vitest/expect@3.2.4':
+    dependencies:
+      '@types/chai': 5.2.2
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.2.1
+      tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.4(vite@7.0.6(@types/node@24.0.13)(jiti@2.4.2)(tsx@4.20.3)(yaml@2.8.0))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.17
+    optionalDependencies:
+      vite: 7.0.6(@types/node@24.0.13)(jiti@2.4.2)(tsx@4.20.3)(yaml@2.8.0)
+
+  '@vitest/pretty-format@3.2.4':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/runner@3.2.4':
+    dependencies:
+      '@vitest/utils': 3.2.4
+      pathe: 2.0.3
+      strip-literal: 3.0.0
+
+  '@vitest/snapshot@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      magic-string: 0.30.17
+      pathe: 2.0.3
+
+  '@vitest/spy@3.2.4':
+    dependencies:
+      tinyspy: 4.0.3
+
+  '@vitest/utils@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      loupe: 3.2.0
+      tinyrainbow: 2.0.0
 
   JSONStream@1.3.5:
     dependencies:
@@ -2169,6 +2530,14 @@ snapshots:
   argparse@2.0.1: {}
 
   array-ify@1.0.0: {}
+
+  assertion-error@2.0.1: {}
+
+  ast-v8-to-istanbul@0.3.3:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.29
+      estree-walker: 3.0.3
+      js-tokens: 9.0.1
 
   balanced-match@1.0.2: {}
 
@@ -2237,7 +2606,17 @@ snapshots:
 
   callsites@3.1.0: {}
 
+  chai@5.2.1:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.1
+      deep-eql: 5.0.2
+      loupe: 3.2.0
+      pathval: 2.0.1
+
   chalk@5.4.1: {}
+
+  check-error@2.1.1: {}
 
   chokidar@4.0.3:
     dependencies:
@@ -2422,6 +2801,8 @@ snapshots:
     dependencies:
       mimic-response: 3.1.0
 
+  deep-eql@5.0.2: {}
+
   deep-extend@0.6.0: {}
 
   depd@2.0.0: {}
@@ -2466,6 +2847,8 @@ snapshots:
 
   es-errors@1.3.0: {}
 
+  es-module-lexer@1.7.0: {}
+
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
@@ -2503,6 +2886,10 @@ snapshots:
 
   escape-html@1.0.3: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   etag@1.8.1: {}
 
   eventemitter3@5.0.1: {}
@@ -2514,6 +2901,8 @@ snapshots:
       eventsource-parser: 3.0.3
 
   expand-template@2.0.3: {}
+
+  expect-type@1.2.2: {}
 
   express-rate-limit@7.5.1(express@5.1.0):
     dependencies:
@@ -2560,6 +2949,10 @@ snapshots:
   fdir@6.4.6(picomatch@4.0.2):
     optionalDependencies:
       picomatch: 4.0.2
+
+  fdir@6.4.6(picomatch@4.0.3):
+    optionalDependencies:
+      picomatch: 4.0.3
 
   file-uri-to-path@1.0.0: {}
 
@@ -2691,6 +3084,8 @@ snapshots:
     optionalDependencies:
       uglify-js: 3.19.3
 
+  has-flag@4.0.0: {}
+
   has-symbols@1.1.0: {}
 
   hasown@2.0.2:
@@ -2700,6 +3095,8 @@ snapshots:
   hosted-git-info@7.0.2:
     dependencies:
       lru-cache: 10.4.3
+
+  html-escaper@2.0.2: {}
 
   http-errors@2.0.0:
     dependencies:
@@ -2756,6 +3153,27 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-lib-source-maps@5.0.6:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.29
+      debug: 4.4.1
+      istanbul-lib-coverage: 3.2.2
+    transitivePeerDependencies:
+      - supports-color
+
+  istanbul-reports@3.1.7:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
   jackspeak@3.4.3:
     dependencies:
       '@isaacs/cliui': 8.0.2
@@ -2771,6 +3189,8 @@ snapshots:
   joycon@3.1.1: {}
 
   js-tokens@4.0.0: {}
+
+  js-tokens@9.0.1: {}
 
   js-yaml@4.1.0:
     dependencies:
@@ -2846,6 +3266,8 @@ snapshots:
       strip-ansi: 7.1.0
       wrap-ansi: 9.0.0
 
+  loupe@3.2.0: {}
+
   lru-cache@10.4.3: {}
 
   lru-cache@11.1.0: {}
@@ -2853,6 +3275,16 @@ snapshots:
   magic-string@0.30.17:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.4
+
+  magicast@0.3.5:
+    dependencies:
+      '@babel/parser': 7.28.0
+      '@babel/types': 7.28.2
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.7.2
 
   math-intrinsics@1.1.0: {}
 
@@ -2909,6 +3341,8 @@ snapshots:
       thenify-all: 1.6.0
 
   nano-spawn@1.0.2: {}
+
+  nanoid@3.3.11: {}
 
   napi-build-utils@2.0.0: {}
 
@@ -2989,11 +3423,15 @@ snapshots:
 
   pathe@2.0.3: {}
 
+  pathval@2.0.1: {}
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
 
   picomatch@4.0.2: {}
+
+  picomatch@4.0.3: {}
 
   pidtree@0.6.0: {}
 
@@ -3007,13 +3445,20 @@ snapshots:
       mlly: 1.7.4
       pathe: 2.0.3
 
-  postcss-load-config@6.0.1(jiti@2.4.2)(tsx@4.20.3)(yaml@2.8.0):
+  postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.6)(tsx@4.20.3)(yaml@2.8.0):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 2.4.2
+      postcss: 8.5.6
       tsx: 4.20.3
       yaml: 2.8.0
+
+  postcss@8.5.6:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
 
   prebuild-install@7.1.3:
     dependencies:
@@ -3209,6 +3654,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@4.1.0: {}
 
   simple-concat@1.0.1: {}
@@ -3228,6 +3675,8 @@ snapshots:
     dependencies:
       ansi-styles: 6.2.1
       is-fullwidth-code-point: 5.0.0
+
+  source-map-js@1.2.1: {}
 
   source-map@0.6.1: {}
 
@@ -3251,9 +3700,13 @@ snapshots:
 
   split2@4.2.0: {}
 
+  stackback@0.0.2: {}
+
   statuses@2.0.1: {}
 
   statuses@2.0.2: {}
+
+  std-env@3.9.0: {}
 
   string-argv@0.3.2: {}
 
@@ -3289,6 +3742,10 @@ snapshots:
 
   strip-json-comments@2.0.1: {}
 
+  strip-literal@3.0.0:
+    dependencies:
+      js-tokens: 9.0.1
+
   sucrase@3.35.0:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.12
@@ -3298,6 +3755,10 @@ snapshots:
       mz: 2.7.0
       pirates: 4.0.7
       ts-interface-checker: 0.1.13
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
 
   tar-fs@2.1.3:
     dependencies:
@@ -3320,6 +3781,12 @@ snapshots:
     dependencies:
       temp-dir: 3.0.0
 
+  test-exclude@7.0.1:
+    dependencies:
+      '@istanbuljs/schema': 0.1.3
+      glob: 10.4.5
+      minimatch: 9.0.5
+
   text-extensions@2.4.0: {}
 
   thenify-all@1.6.0:
@@ -3332,6 +3799,8 @@ snapshots:
 
   through@2.3.8: {}
 
+  tinybench@2.9.0: {}
+
   tinyexec@0.3.2: {}
 
   tinyexec@1.0.1: {}
@@ -3340,6 +3809,12 @@ snapshots:
     dependencies:
       fdir: 6.4.6(picomatch@4.0.2)
       picomatch: 4.0.2
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@2.0.0: {}
+
+  tinyspy@4.0.3: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -3355,7 +3830,7 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  tsup@8.5.0(jiti@2.4.2)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0):
+  tsup@8.5.0(jiti@2.4.2)(postcss@8.5.6)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.25.6)
       cac: 6.7.14
@@ -3366,7 +3841,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(jiti@2.4.2)(tsx@4.20.3)(yaml@2.8.0)
+      postcss-load-config: 6.0.1(jiti@2.4.2)(postcss@8.5.6)(tsx@4.20.3)(yaml@2.8.0)
       resolve-from: 5.0.0
       rollup: 4.44.2
       source-map: 0.8.0-beta.0
@@ -3375,6 +3850,7 @@ snapshots:
       tinyglobby: 0.2.14
       tree-kill: 1.2.2
     optionalDependencies:
+      postcss: 8.5.6
       typescript: 5.8.3
     transitivePeerDependencies:
       - jiti
@@ -3427,6 +3903,83 @@ snapshots:
 
   vary@1.1.2: {}
 
+  vite-node@3.2.4(@types/node@24.0.13)(jiti@2.4.2)(tsx@4.20.3)(yaml@2.8.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.1
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.0.6(@types/node@24.0.13)(jiti@2.4.2)(tsx@4.20.3)(yaml@2.8.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vite@7.0.6(@types/node@24.0.13)(jiti@2.4.2)(tsx@4.20.3)(yaml@2.8.0):
+    dependencies:
+      esbuild: 0.25.6
+      fdir: 6.4.6(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.6
+      rollup: 4.44.2
+      tinyglobby: 0.2.14
+    optionalDependencies:
+      '@types/node': 24.0.13
+      fsevents: 2.3.3
+      jiti: 2.4.2
+      tsx: 4.20.3
+      yaml: 2.8.0
+
+  vitest@3.2.4(@types/node@24.0.13)(jiti@2.4.2)(tsx@4.20.3)(yaml@2.8.0):
+    dependencies:
+      '@types/chai': 5.2.2
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@7.0.6(@types/node@24.0.13)(jiti@2.4.2)(tsx@4.20.3)(yaml@2.8.0))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.2.1
+      debug: 4.4.1
+      expect-type: 1.2.2
+      magic-string: 0.30.17
+      pathe: 2.0.3
+      picomatch: 4.0.2
+      std-env: 3.9.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.14
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.0.6(@types/node@24.0.13)(jiti@2.4.2)(tsx@4.20.3)(yaml@2.8.0)
+      vite-node: 3.2.4(@types/node@24.0.13)(jiti@2.4.2)(tsx@4.20.3)(yaml@2.8.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.0.13
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   webidl-conversions@4.0.2: {}
 
   whatwg-url@7.1.0:
@@ -3438,6 +3991,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   wordwrap@1.0.0: {}
 

--- a/mcp-server/src/__tests__/fixtures/activity-log.ts
+++ b/mcp-server/src/__tests__/fixtures/activity-log.ts
@@ -1,0 +1,170 @@
+/**
+ * Test fixtures for activity logging
+ */
+
+export const sampleActivities = [
+  {
+    activity: 'Created user authentication module',
+    activity_type: 'create',
+    tool_name: 'code-generator',
+    success: true,
+    tags: ['authentication', 'feature', 'backend'],
+    context: 'Implementing JWT-based authentication for the API',
+    files_affected: ['src/auth/jwt.ts', 'src/auth/middleware.ts'],
+    issue_number: 123,
+    link: 'https://github.com/owner/repo/pull/456'
+  },
+  {
+    activity: 'Fixed memory leak in event handler',
+    activity_type: 'fix',
+    tool_name: 'debugger',
+    success: true,
+    tags: ['bug-fix', 'performance', 'critical'],
+    context: 'Event listeners were not being properly removed',
+    files_affected: ['src/events/handler.ts'],
+    issue_number: 789,
+    link: 'https://github.com/owner/repo/issues/789'
+  },
+  {
+    activity: 'Updated API documentation',
+    activity_type: 'update',
+    tool_name: 'doc-generator',
+    success: true,
+    tags: ['documentation', 'api'],
+    context: 'Added examples for new endpoints',
+    files_affected: ['docs/api/endpoints.md', 'docs/api/examples.md']
+  },
+  {
+    activity: 'Deployed to production',
+    activity_type: 'deploy',
+    tool_name: 'ci-cd',
+    success: false,
+    error: 'Health check failed after deployment',
+    tags: ['deployment', 'production'],
+    context: 'Version 2.1.0 deployment attempt'
+  },
+  {
+    activity: 'Researched caching strategies',
+    activity_type: 'research',
+    tool_name: 'browser',
+    success: true,
+    tags: ['research', 'performance', 'caching'],
+    context: 'Evaluating Redis vs Memcached for session storage'
+  }
+];
+
+export const activityWithAllFields = {
+  activity: 'Comprehensive test activity',
+  activity_type: 'test',
+  tool_name: 'test-runner',
+  success: true,
+  error: null,
+  tags: ['test', 'comprehensive', 'fixture'],
+  context: 'This activity has all possible fields filled',
+  files_affected: ['test/file1.ts', 'test/file2.ts', 'test/file3.ts'],
+  issue_number: 999,
+  link: 'https://example.com/test'
+};
+
+export const activityWithMinimalFields = {
+  activity: 'Minimal activity',
+  tool_name: 'minimal-tool'
+};
+
+export const failedActivity = {
+  activity: 'Failed database migration',
+  activity_type: 'update',
+  tool_name: 'migration-tool',
+  success: false,
+  error: 'Column "user_id" already exists',
+  tags: ['database', 'migration', 'error'],
+  context: 'Attempting to add user_id column to posts table'
+};
+
+export const activitiesForFiltering = [
+  {
+    activity: 'Task 1',
+    activity_type: 'create',
+    tool_name: 'tool-a',
+    success: true,
+    tags: ['frontend', 'react'],
+    timestamp: '2024-01-01T10:00:00Z'
+  },
+  {
+    activity: 'Task 2',
+    activity_type: 'update',
+    tool_name: 'tool-b',
+    success: true,
+    tags: ['backend', 'api'],
+    timestamp: '2024-01-01T11:00:00Z'
+  },
+  {
+    activity: 'Task 3',
+    activity_type: 'fix',
+    tool_name: 'tool-a',
+    success: false,
+    error: 'Test error',
+    tags: ['frontend', 'bug'],
+    timestamp: '2024-01-01T12:00:00Z'
+  },
+  {
+    activity: 'Task 4',
+    activity_type: 'create',
+    tool_name: 'tool-c',
+    success: true,
+    tags: ['backend', 'database'],
+    timestamp: '2024-01-02T10:00:00Z'
+  }
+];
+
+export const longActivity = {
+  activity: 'A'.repeat(1000), // Very long activity description
+  tool_name: 'stress-test',
+  context: 'B'.repeat(500), // Long context
+  files_affected: Array.from({ length: 100 }, (_, i) => `file${i}.ts`) // Many files
+};
+
+export const specialCharacterActivity = {
+  activity: "Activity with 'quotes' and \"double quotes\"",
+  tool_name: "tool's name",
+  context: `Multi-line
+context with
+special chars: \t\n\r`,
+  tags: ['tag-with-dash', 'tag_with_underscore', 'tag.with.dot'],
+  link: 'https://example.com?query=value&other=123#fragment'
+};
+
+export const activityTypes = [
+  'create',
+  'update',
+  'fix',
+  'review',
+  'research',
+  'document',
+  'test',
+  'deploy',
+  'configure',
+  'refactor',
+  'delete',
+  'analyze',
+  'plan',
+  'debug'
+];
+
+export const commonTags = [
+  'bug-fix',
+  'feature',
+  'enhancement',
+  'documentation',
+  'testing',
+  'refactoring',
+  'performance',
+  'security',
+  'ui-ux',
+  'api',
+  'database',
+  'infrastructure',
+  'ci-cd',
+  'dependency-update',
+  'breaking-change'
+];

--- a/mcp-server/src/__tests__/fixtures/config.ts
+++ b/mcp-server/src/__tests__/fixtures/config.ts
@@ -1,0 +1,167 @@
+/**
+ * Test fixtures for configuration data
+ */
+
+export const minimalConfig = `
+contexts:
+  - name: project
+    path: .
+`;
+
+export const fullConfig = `
+# Shared configuration
+shared:
+  tools:
+    github:
+      credentials:
+        method: github-cli
+    linear:
+      credentials:
+        method: env
+        api_key_var: LINEAR_API_KEY
+  formatting:
+    code_style: prettier
+    indent_size: 2
+
+# Context-specific configurations
+contexts:
+  - name: backend
+    path: ./backend
+    description: Backend API service
+    tools:
+      github:
+        enabled: true
+        repository: owner/backend-repo
+      linear:
+        enabled: true
+        team_id: TEAM-123
+    prompts:
+      - name: api-development
+        enabled: true
+      - name: database-migration
+        enabled: true
+    formatting:
+      indent_size: 4  # Override shared setting
+
+  - name: frontend
+    path: ./frontend
+    description: Frontend application
+    tools:
+      github:
+        enabled: true
+        repository: owner/frontend-repo
+    prompts:
+      - name: component-development
+        enabled: true
+      - name: ui-testing
+        enabled: true
+
+  - name: docs
+    path: ./docs
+    description: Documentation
+    tools:
+      github:
+        enabled: false  # Disable for docs
+    prompts:
+      - name: documentation
+        enabled: true
+`;
+
+export const configWithInvalidYAML = `
+contexts:
+  - name: project
+    path: .
+    invalid_indent: should cause error
+  bad_key
+`;
+
+export const configWithoutContexts = `
+shared:
+  tools:
+    github:
+      enabled: true
+`;
+
+export const configWithEmptyContexts = `
+contexts: []
+`;
+
+export const configWithDuplicateContexts = `
+contexts:
+  - name: duplicate
+    path: ./path1
+  - name: duplicate
+    path: ./path2
+`;
+
+export const configWithToolOverrides = `
+shared:
+  tools:
+    github:
+      credentials:
+        method: token
+        token_var: GITHUB_TOKEN
+      enabled: true
+
+contexts:
+  - name: project
+    path: .
+    tools:
+      github:
+        credentials:
+          method: github-cli  # Override shared
+        repository: test/repo
+`;
+
+export const configWithPromptSettings = `
+contexts:
+  - name: project
+    path: .
+    prompts:
+      - name: test-prompt
+        enabled: true
+        custom_args:
+          arg1: value1
+          arg2: value2
+      - name: disabled-prompt
+        enabled: false
+`;
+
+export const nestedPathConfig = `
+contexts:
+  - name: root
+    path: .
+  - name: deep-nested
+    path: ./src/components/ui/buttons
+  - name: parent-path
+    path: ../
+`;
+
+export const configWithCustomFields = `
+contexts:
+  - name: project
+    path: .
+    custom_field: custom_value
+    nested_custom:
+      field1: value1
+      field2: value2
+    tools:
+      custom_tool:
+        setting1: value1
+`;
+
+export const multiContextConfig = `
+contexts:
+  - name: monorepo-root
+    path: .
+    description: Monorepo root
+  - name: package-a
+    path: ./packages/a
+    description: Package A
+  - name: package-b
+    path: ./packages/b
+    description: Package B
+  - name: shared-lib
+    path: ./libs/shared
+    description: Shared library
+`;

--- a/mcp-server/src/__tests__/fixtures/index.ts
+++ b/mcp-server/src/__tests__/fixtures/index.ts
@@ -1,0 +1,130 @@
+/**
+ * Central export for all test fixtures
+ */
+
+export * from './prompts.js';
+export * from './config.js';
+export * from './activity-log.js';
+
+/**
+ * Common test constants
+ */
+export const TEST_PROJECT_PATH = '/test/project';
+export const TEST_TIMEOUT = 5000;
+
+/**
+ * Mock file system structure
+ */
+export const mockFileSystem = {
+  '/test/project': {
+    '.simone': {
+      'prompts': {
+        'test-prompt.yaml': 'prompt content',
+        'another-prompt.yaml': 'another content'
+      },
+      'partials': {
+        'common.hbs': '{{> header}}\n{{> footer}}',
+        'header.hbs': '<header>{{title}}</header>',
+        'footer.hbs': '<footer>Copyright {{year}}</footer>'
+      },
+      'config.yaml': 'config content',
+      'simone.db': 'database file'
+    },
+    'src': {
+      'index.ts': 'export default function() {}',
+      'utils.ts': 'export const helper = () => {}'
+    },
+    'package.json': JSON.stringify({
+      name: 'test-project',
+      version: '1.0.0',
+      dependencies: {}
+    }),
+    'README.md': '# Test Project',
+    'CLAUDE.md': '# Claude Instructions\n\nTest instructions'
+  }
+};
+
+/**
+ * Mock MCP message samples
+ */
+export const mockMcpMessages = {
+  listPromptsRequest: {
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'prompts/list',
+    params: {}
+  },
+  getPromptRequest: {
+    jsonrpc: '2.0',
+    id: 2,
+    method: 'prompts/get',
+    params: {
+      name: 'test-prompt',
+      arguments: {
+        arg1: 'value1'
+      }
+    }
+  },
+  listToolsRequest: {
+    jsonrpc: '2.0',
+    id: 3,
+    method: 'tools/list',
+    params: {}
+  },
+  callToolRequest: {
+    jsonrpc: '2.0',
+    id: 4,
+    method: 'tools/call',
+    params: {
+      name: 'log_activity',
+      arguments: {
+        activity: 'Test activity',
+        tool_name: 'test'
+      }
+    }
+  }
+};
+
+/**
+ * Error scenarios for testing
+ */
+export const errorScenarios = {
+  databaseErrors: [
+    { 
+      error: new Error('SQLITE_BUSY: database is locked'),
+      type: 'busy'
+    },
+    {
+      error: new Error('SQLITE_FULL: database or disk is full'),
+      type: 'full'
+    },
+    {
+      error: new Error('SQLITE_CONSTRAINT: UNIQUE constraint failed'),
+      type: 'constraint'
+    }
+  ],
+  fileSystemErrors: [
+    {
+      error: new Error('ENOENT: no such file or directory'),
+      type: 'notFound'
+    },
+    {
+      error: new Error('EACCES: permission denied'),
+      type: 'permission'
+    },
+    {
+      error: new Error('EISDIR: illegal operation on a directory'),
+      type: 'isDirectory'
+    }
+  ],
+  networkErrors: [
+    {
+      error: new Error('ECONNREFUSED: Connection refused'),
+      type: 'connectionRefused'
+    },
+    {
+      error: new Error('ETIMEDOUT: Request timeout'),
+      type: 'timeout'
+    }
+  ]
+};

--- a/mcp-server/src/__tests__/fixtures/prompts.ts
+++ b/mcp-server/src/__tests__/fixtures/prompts.ts
@@ -1,0 +1,154 @@
+/**
+ * Test fixtures for prompt templates
+ */
+
+export const simplePrompt = `
+name: simple-prompt
+description: A simple test prompt
+version: 1.0.0
+authors:
+  - Test Author
+messages:
+  - role: system
+    content: |
+      This is a simple test prompt
+`;
+
+export const promptWithArguments = `
+name: prompt-with-args
+description: A prompt with arguments
+version: 1.0.0
+authors:
+  - Test Author
+arguments:
+  - name: required_arg
+    description: A required argument
+    required: true
+  - name: optional_arg
+    description: An optional argument
+    required: false
+    default: "default value"
+messages:
+  - role: system
+    content: |
+      Required: {{required_arg}}
+      Optional: {{optional_arg}}
+`;
+
+export const promptWithPartials = `
+name: prompt-with-partials
+description: A prompt that uses partials
+version: 1.0.0
+partials:
+  - greeting
+messages:
+  - role: system
+    content: |
+      {{> greeting}}
+      This prompt uses partials.
+`;
+
+export const promptWithHelpers = `
+name: prompt-with-helpers
+description: A prompt using Handlebars helpers
+version: 1.0.0
+arguments:
+  - name: value
+    description: A numeric value
+    required: true
+  - name: threshold
+    description: Threshold for comparison
+    required: false
+    default: 10
+messages:
+  - role: system
+    content: |
+      {{#if (gt value threshold)}}
+      Value {{value}} is greater than {{threshold}}
+      {{else}}
+      Value {{value}} is not greater than {{threshold}}
+      {{/if}}
+`;
+
+export const complexPrompt = `
+name: complex-prompt
+description: A complex prompt with all features
+version: 2.0.0
+authors:
+  - Primary Author
+  - Secondary Author
+tags:
+  - complex
+  - testing
+  - advanced
+arguments:
+  - name: user_name
+    description: The user's name
+    required: true
+  - name: task_type
+    description: Type of task to perform
+    required: true
+  - name: priority
+    description: Task priority level
+    required: false
+    default: "normal"
+  - name: options
+    description: Additional options
+    required: false
+partials:
+  - common-instructions
+  - formatting-guide
+messages:
+  - role: system
+    content: |
+      {{> common-instructions}}
+      
+      Hello {{user_name}}, you have requested a {{task_type}} task.
+      
+      {{#if (eq priority "high")}}
+      ⚠️ This is a HIGH PRIORITY task!
+      {{else if (eq priority "low")}}
+      This is a low priority task.
+      {{else}}
+      This is a normal priority task.
+      {{/if}}
+      
+      {{#if options}}
+      Additional options: {{options}}
+      {{/if}}
+      
+      {{> formatting-guide}}
+  - role: user
+    content: |
+      Please proceed with the {{task_type}} task.
+`;
+
+export const invalidPromptYAML = `
+name: invalid-yaml
+description: "This has invalid YAML syntax
+version: 1.0.0
+  messages:
+    role: system
+  content: Invalid
+`;
+
+export const promptMissingName = `
+description: Missing name field
+version: 1.0.0
+messages:
+  - role: system
+    content: This prompt has no name
+`;
+
+export const promptMissingMessages = `
+name: no-messages
+description: This prompt has no messages
+version: 1.0.0
+`;
+
+export const minimalPrompt = `
+name: minimal
+messages:
+  - role: system
+    content: Minimal prompt
+`;

--- a/mcp-server/src/__tests__/server.integration.test.ts
+++ b/mcp-server/src/__tests__/server.integration.test.ts
@@ -1,0 +1,501 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import {
+  ListPromptsRequestSchema,
+  GetPromptRequestSchema,
+  ListToolsRequestSchema,
+  CallToolRequestSchema,
+  type ListPromptsResult,
+  type GetPromptResult,
+  type ListToolsResult,
+  type CallToolResult,
+} from '@modelcontextprotocol/sdk/types.js';
+import { createTestDatabase } from './utils/test-database.js';
+import { join } from 'path';
+import { mkdirSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import Database from 'better-sqlite3';
+
+// Mock environment and modules
+vi.mock('../utils/logger.js', () => ({
+  initializeLogger: vi.fn(),
+  logError: vi.fn().mockResolvedValue(undefined),
+  logDebug: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs')>();
+  return {
+    ...actual,
+    watch: vi.fn((path, options, callback) => {
+      // Return a mock watcher
+      return {
+        close: vi.fn(),
+      };
+    }),
+  };
+});
+
+// We'll test the actual handlers directly instead of mocking the server
+describe('MCP Server Integration Tests', () => {
+  let testProjectPath: string;
+  let db: Database.Database;
+  let originalEnv: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    // Clear all module cache
+    vi.resetModules();
+    
+    // Save original env
+    originalEnv = { ...process.env };
+    
+    // Create test project directory
+    testProjectPath = join(tmpdir(), `mcp-test-${Date.now()}`);
+    mkdirSync(testProjectPath, { recursive: true });
+    mkdirSync(join(testProjectPath, '.simone'), { recursive: true });
+    mkdirSync(join(testProjectPath, '.simone', 'prompts'), { recursive: true });
+    mkdirSync(join(testProjectPath, '.simone', 'partials'), { recursive: true });
+    
+    // Set environment
+    process.env['PROJECT_PATH'] = testProjectPath;
+    process.env['NODE_ENV'] = 'test';
+    
+    // Create test database
+    db = createTestDatabase();
+    
+    // Mock the DatabaseConnection to use our test database
+    vi.doMock('../tools/database.js', () => ({
+      DatabaseConnection: vi.fn().mockImplementation(() => ({
+        getDb: () => db,
+        close: () => db.close(),
+      })),
+    }));
+  });
+
+  afterEach(() => {
+    // Restore environment
+    process.env = originalEnv;
+    
+    // Clean up
+    if (db && db.open) {
+      db.close();
+    }
+    
+    // Remove test directory
+    try {
+      rmSync(testProjectPath, { recursive: true, force: true });
+    } catch (error) {
+      // Ignore cleanup errors
+    }
+    
+    // Clear all mocks
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  describe('Configuration', () => {
+    it('should handle missing PROJECT_PATH environment variable', async () => {
+      delete process.env['PROJECT_PATH'];
+      
+      const config = await import('../config/index.js');
+      
+      expect(() => {
+        config.getEnvConfig();
+      }).toThrow('PROJECT_PATH environment variable is required');
+    });
+
+    it('should initialize with valid PROJECT_PATH', async () => {
+      const config = await import('../config/index.js');
+      expect(config.getEnvConfig().projectPath).toBe(testProjectPath);
+    });
+  });
+
+  describe('Prompt System', () => {
+    beforeEach(() => {
+      // Create test prompt file
+      const promptContent = `
+name: test-prompt
+description: A test prompt
+version: 1.0.0
+authors:
+  - Test Author
+arguments:
+  - name: arg1
+    description: First argument
+    required: true
+  - name: arg2
+    description: Second argument
+    required: false
+    default: "default value"
+tags:
+  - test
+  - example
+template: |
+  This is a test prompt with arg1: {{arg1}} and arg2: {{arg2}}
+`;
+      writeFileSync(
+        join(testProjectPath, '.simone', 'prompts', 'test-prompt.yaml'),
+        promptContent
+      );
+    });
+
+    it('should list available prompts', async () => {
+      const { initializeTemplating } = await import('../templates/index.js');
+      const promptHandler = initializeTemplating(testProjectPath);
+      
+      const prompts = await promptHandler.listAvailablePrompts();
+      
+      const testPrompt = prompts.find(p => p.name === 'test-prompt');
+      expect(testPrompt).toBeDefined();
+      expect(testPrompt?.description).toBe('A test prompt');
+      expect(testPrompt?.arguments).toHaveLength(2);
+    });
+
+    it('should get prompt with arguments', async () => {
+      const { initializeTemplating } = await import('../templates/index.js');
+      const promptHandler = initializeTemplating(testProjectPath);
+      
+      const messages = await promptHandler.getPromptMessages('test-prompt', {
+        arg1: 'value1',
+        arg2: 'custom value',
+      });
+      
+      expect(messages).toHaveLength(1);
+      expect(messages[0].role).toBe('user');
+      expect(messages[0].content).toBeDefined();
+      
+      // Check content (could be a string or object)
+      const content = typeof messages[0].content === 'string' 
+        ? messages[0].content 
+        : messages[0].content.text;
+      
+      // Content includes header with context info
+      expect(content).toContain('Context Information');
+      expect(content).toContain('Project Path');
+      
+      // And our actual prompt content
+      expect(content).toContain('value1');
+      expect(content).toContain('custom value');
+    });
+
+    it('should use default values for optional arguments', async () => {
+      const { initializeTemplating } = await import('../templates/index.js');
+      const promptHandler = initializeTemplating(testProjectPath);
+      
+      const messages = await promptHandler.getPromptMessages('test-prompt', {
+        arg1: 'value1',
+      });
+      
+      expect(messages).toHaveLength(1);
+      
+      // Check content (could be a string or object)
+      const content = typeof messages[0].content === 'string' 
+        ? messages[0].content 
+        : messages[0].content.text;
+      
+      // Content includes header with context info
+      expect(content).toContain('Context Information');
+      
+      // And our actual prompt content
+      expect(content).toContain('value1');
+      expect(content).toContain('default value');
+    });
+
+    it('should handle non-existent prompt', async () => {
+      const { initializeTemplating } = await import('../templates/index.js');
+      const promptHandler = initializeTemplating(testProjectPath);
+      
+      const messages = await promptHandler.getPromptMessages('non-existent', {});
+      
+      expect(messages).toHaveLength(1);
+      expect(messages[0].role).toBe('user');
+      
+      const content = typeof messages[0].content === 'string' 
+        ? messages[0].content 
+        : messages[0].content.text;
+      
+      expect(content).toContain('error happened');
+      expect(content).toContain("Prompt 'non-existent' not found");
+    });
+  });
+
+  describe('Tool System', () => {
+    it('should list available tools', async () => {
+      const { ActivityLogger } = await import('../tools/activity-logger/index.js');
+      const { getTools, getToolSchemas } = await import('../tools/index.js');
+      
+      const context = {
+        projectPath: testProjectPath,
+        activityLogger: new ActivityLogger(testProjectPath, db),
+        database: db,
+      };
+      
+      const tools = getTools(context);
+      const schemas = getToolSchemas(tools);
+      
+      const logTool = schemas.find(t => t.name === 'log_activity');
+      expect(logTool).toBeDefined();
+      expect(logTool?.description).toContain('Log your AI-assisted development activities');
+    });
+
+    it('should call activity logger tool successfully', async () => {
+      const { ActivityLogger } = await import('../tools/activity-logger/index.js');
+      const { getTools, handleToolCall } = await import('../tools/index.js');
+      
+      const context = {
+        projectPath: testProjectPath,
+        activityLogger: new ActivityLogger(testProjectPath, db),
+        database: db,
+      };
+      
+      const tools = getTools(context);
+      const result = await handleToolCall(
+        'log_activity',
+        {
+          activity: 'Test activity',
+          tool_name: 'test-tool',
+          tags: ['test', 'integration'],
+        },
+        tools,
+        context
+      );
+      
+      expect(result.content[0].text).toContain('Activity logged successfully');
+      expect(result.isError).toBeUndefined();
+    });
+
+    it('should handle unknown tool', async () => {
+      const { ActivityLogger } = await import('../tools/activity-logger/index.js');
+      const { getTools, handleToolCall } = await import('../tools/index.js');
+      
+      const context = {
+        projectPath: testProjectPath,
+        activityLogger: new ActivityLogger(testProjectPath, db),
+        database: db,
+      };
+      
+      const tools = getTools(context);
+      const result = await handleToolCall(
+        'unknown-tool',
+        {},
+        tools,
+        context
+      );
+      
+      expect(result.content[0].text).toContain('Unknown tool: unknown-tool');
+      expect(result.isError).toBe(true);
+    });
+
+    it('should handle tool errors gracefully', async () => {
+      // Close database to simulate error
+      db.close();
+      
+      const { ActivityLogger } = await import('../tools/activity-logger/index.js');
+      const { getTools, handleToolCall } = await import('../tools/index.js');
+      
+      const context = {
+        projectPath: testProjectPath,
+        activityLogger: new ActivityLogger(testProjectPath, db),
+        database: db,
+      };
+      
+      const tools = getTools(context);
+      const result = await handleToolCall(
+        'log_activity',
+        {
+          activity: 'Test activity',
+          tool_name: 'test-tool',
+        },
+        tools,
+        context
+      );
+      
+      expect(result.content[0].text).toContain('CRITICAL ERROR');
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  describe('Hot Reload', () => {
+    it('should watch for prompt changes', async () => {
+      const { watch } = await import('fs');
+      
+      // Mock process.exit to prevent actual exit
+      const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => {
+        throw new Error('Process would exit');
+      });
+      
+      try {
+        await import('../index.js');
+      } catch (error) {
+        // Expected due to mocked exit
+      }
+      
+      // Verify watch was called for prompts directory
+      expect(watch).toHaveBeenCalledWith(
+        join(testProjectPath, '.simone', 'prompts'),
+        expect.objectContaining({ recursive: true }),
+        expect.any(Function)
+      );
+      
+      mockExit.mockRestore();
+    });
+
+    it('should not watch built-in prompts in production', async () => {
+      process.env['NODE_ENV'] = 'production';
+      const { watch } = await import('fs');
+      
+      // Mock process.exit
+      const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => {
+        throw new Error('Process would exit');
+      });
+      
+      try {
+        await import('../index.js');
+      } catch (error) {
+        // Expected
+      }
+      
+      // Should only be called once for project prompts
+      const watchCalls = (watch as any).mock.calls;
+      const projectPromptCalls = watchCalls.filter((call: any[]) => 
+        call[0].includes('.simone')
+      );
+      
+      expect(projectPromptCalls).toHaveLength(1);
+      
+      mockExit.mockRestore();
+    });
+  });
+
+  describe('Database Integration', () => {
+    it('should initialize database connection', async () => {
+      const { DatabaseConnection } = await import('../tools/database.js');
+      const dbConn = new DatabaseConnection(testProjectPath);
+      const database = dbConn.getDb();
+      
+      // Verify database tables exist
+      const tables = database.prepare("SELECT name FROM sqlite_master WHERE type='table'").all();
+      const tableNames = tables.map((t: any) => t.name);
+      
+      expect(tableNames).toContain('activity_log');
+      dbConn.close();
+    });
+
+    it('should handle database initialization errors', async () => {
+      // Reset modules to clear any cached imports
+      vi.resetModules();
+      
+      // Mock DatabaseConnection to throw
+      vi.doMock('../tools/database.js', () => ({
+        DatabaseConnection: vi.fn().mockImplementation(() => {
+          throw new Error('Database initialization failed');
+        }),
+      }));
+
+      // Mock process.exit to prevent actual exit
+      const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => {
+        // Don't throw, just return
+        return undefined as never;
+      });
+
+      // Import will trigger the database error
+      try {
+        await import('../index.js');
+        // If we get here, wait a bit for the async error handler
+        await new Promise(resolve => setTimeout(resolve, 100));
+      } catch (error) {
+        // Might throw the original database error before exit is called
+      }
+
+      expect(mockExit).toHaveBeenCalledWith(1);
+      mockExit.mockRestore();
+    });
+  });
+
+  describe('Graceful Shutdown', () => {
+    beforeEach(() => {
+      // Remove any existing listeners to avoid interference
+      process.removeAllListeners('SIGTERM');
+      process.removeAllListeners('SIGINT');
+    });
+
+    it('should handle SIGTERM signal', async () => {
+      const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => {
+        // Don't actually exit
+      });
+
+      // Import server which sets up signal handlers
+      try {
+        await import('../index.js');
+      } catch (error) {
+        // May error due to mocking
+      }
+
+      // Emit SIGTERM
+      process.emit('SIGTERM' as any);
+
+      // Wait a bit for async handler
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      expect(mockExit).toHaveBeenCalledWith(0);
+      mockExit.mockRestore();
+    });
+
+    it('should handle SIGINT signal', async () => {
+      const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => {
+        // Don't actually exit
+      });
+
+      // Import server
+      try {
+        await import('../index.js');
+      } catch (error) {
+        // May error due to mocking
+      }
+
+      // Emit SIGINT
+      process.emit('SIGINT' as any);
+
+      // Wait a bit for async handler
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      expect(mockExit).toHaveBeenCalledWith(0);
+      mockExit.mockRestore();
+    });
+
+    it('should close database on shutdown', async () => {
+      const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => {
+        // Don't actually exit
+      });
+
+      let closeCalled = false;
+      vi.doMock('../tools/database.js', () => ({
+        DatabaseConnection: vi.fn().mockImplementation(() => ({
+          getDb: () => db,
+          close: () => {
+            closeCalled = true;
+            db.close();
+          },
+        })),
+      }));
+
+      // Re-import to use new mock
+      vi.resetModules();
+      
+      try {
+        await import('../index.js');
+      } catch (error) {
+        // May error due to mocking
+      }
+
+      // Emit signal
+      process.emit('SIGTERM' as any);
+
+      // Wait a bit
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      expect(closeCalled).toBe(true);
+      mockExit.mockRestore();
+    });
+  });
+});

--- a/mcp-server/src/__tests__/utils/fixtures.ts
+++ b/mcp-server/src/__tests__/utils/fixtures.ts
@@ -1,0 +1,160 @@
+import { join } from 'path';
+import { existsSync, mkdirSync, writeFileSync, rmSync, readFileSync } from 'fs';
+import { randomBytes } from 'crypto';
+
+export class TestFixtures {
+  private fixtureRoot: string;
+  private createdPaths: string[] = [];
+
+  constructor(testName: string) {
+    this.fixtureRoot = join(__dirname, '../fixtures', testName, randomBytes(8).toString('hex'));
+  }
+
+  getRoot(): string {
+    if (!existsSync(this.fixtureRoot)) {
+      mkdirSync(this.fixtureRoot, { recursive: true });
+      this.createdPaths.push(this.fixtureRoot);
+    }
+    return this.fixtureRoot;
+  }
+
+  createFile(relativePath: string, content: string): string {
+    const fullPath = join(this.getRoot(), relativePath);
+    const dir = join(fullPath, '..');
+    
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true });
+    }
+    
+    writeFileSync(fullPath, content);
+    this.createdPaths.push(fullPath);
+    
+    return fullPath;
+  }
+
+  createDirectory(relativePath: string): string {
+    const fullPath = join(this.getRoot(), relativePath);
+    
+    if (!existsSync(fullPath)) {
+      mkdirSync(fullPath, { recursive: true });
+      this.createdPaths.push(fullPath);
+    }
+    
+    return fullPath;
+  }
+
+  readFile(relativePath: string): string {
+    const fullPath = join(this.getRoot(), relativePath);
+    return readFileSync(fullPath, 'utf-8');
+  }
+
+  cleanup(): void {
+    if (existsSync(this.fixtureRoot)) {
+      rmSync(this.fixtureRoot, { recursive: true, force: true });
+    }
+  }
+}
+
+// Common test fixtures
+export const TEST_TEMPLATES = {
+  simplePrompt: `---
+id: test-prompt
+name: Test Prompt
+description: A simple test prompt
+metadata:
+  version: "1.0"
+  category: test
+variables:
+  - name: testVar
+    description: Test variable
+    required: true
+---
+
+This is a test prompt with {{testVar}}.`,
+
+  promptWithPartial: `---
+id: test-with-partial
+name: Test With Partial
+description: A prompt using partials
+metadata:
+  version: "1.0"
+  category: test
+---
+
+{{> header}}
+Main content here.
+{{> footer}}`,
+
+  invalidYaml: `---
+id: invalid
+name: Invalid YAML
+description: [unclosed array
+---
+
+Content here.`,
+
+  emptyPrompt: `---
+id: empty
+name: Empty Prompt
+---
+
+`,
+
+  complexPrompt: `---
+id: complex
+name: Complex Prompt
+description: A complex prompt with multiple features
+metadata:
+  version: "2.0"
+  category: advanced
+  tags:
+    - test
+    - complex
+variables:
+  - name: userName
+    description: User's name
+    required: true
+  - name: projectName
+    description: Project name
+    required: false
+    default: "Untitled"
+helpers:
+  - uppercase
+  - formatDate
+---
+
+Hello {{uppercase userName}}!
+
+Working on project: {{projectName}}
+
+{{#if complexCondition}}
+Complex logic here
+{{else}}
+Simple fallback
+{{/if}}
+
+Generated on: {{formatDate timestamp}}`
+};
+
+export const TEST_CONFIGS = {
+  minimal: {
+    projectPath: '/test/project',
+    projectName: 'Test Project'
+  },
+  
+  full: {
+    projectPath: '/test/project',
+    projectName: 'Test Project',
+    description: 'A test project for unit tests',
+    techStack: {
+      language: 'TypeScript',
+      framework: 'Node.js',
+      packageManager: 'pnpm'
+    },
+    structure: {
+      src: 'Source files',
+      tests: 'Test files',
+      docs: 'Documentation'
+    }
+  }
+};

--- a/mcp-server/src/__tests__/utils/index.ts
+++ b/mcp-server/src/__tests__/utils/index.ts
@@ -1,0 +1,4 @@
+export * from './mcp-transport-mock.js';
+export * from './test-database.js';
+export * from './mock-logger.js';
+export * from './fixtures.js';

--- a/mcp-server/src/__tests__/utils/mcp-transport-mock.ts
+++ b/mcp-server/src/__tests__/utils/mcp-transport-mock.ts
@@ -1,0 +1,70 @@
+import { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
+import { JSONRPCRequest, JSONRPCResponse, JSONRPCNotification } from '@modelcontextprotocol/sdk/shared/types.js';
+import { EventEmitter } from 'events';
+
+export class MockTransport extends EventEmitter implements Transport {
+  private requests: JSONRPCRequest[] = [];
+  private responses: JSONRPCResponse[] = [];
+  private notifications: JSONRPCNotification[] = [];
+  private isClosed = false;
+
+  async start(): Promise<void> {
+    // Mock transport starts immediately
+  }
+
+  async close(): Promise<void> {
+    if (this.isClosed) return;
+    this.isClosed = true;
+    this.emit('close');
+  }
+
+  async send(data: JSONRPCRequest | JSONRPCNotification | JSONRPCResponse): Promise<void> {
+    if (this.isClosed) {
+      throw new Error('Transport is closed');
+    }
+
+    if ('id' in data && data.id !== undefined) {
+      if ('method' in data) {
+        this.requests.push(data as JSONRPCRequest);
+      } else {
+        this.responses.push(data as JSONRPCResponse);
+      }
+    } else {
+      this.notifications.push(data as JSONRPCNotification);
+    }
+  }
+
+  // Test helper methods
+  getRequests(): JSONRPCRequest[] {
+    return [...this.requests];
+  }
+
+  getResponses(): JSONRPCResponse[] {
+    return [...this.responses];
+  }
+
+  getNotifications(): JSONRPCNotification[] {
+    return [...this.notifications];
+  }
+
+  clearHistory(): void {
+    this.requests = [];
+    this.responses = [];
+    this.notifications = [];
+  }
+
+  // Simulate receiving a message
+  simulateMessage(message: JSONRPCRequest | JSONRPCNotification | JSONRPCResponse): void {
+    this.emit('message', message);
+  }
+
+  // Simulate connection error
+  simulateError(error: Error): void {
+    this.emit('error', error);
+  }
+
+  // Check if transport is closed
+  get closed(): boolean {
+    return this.isClosed;
+  }
+}

--- a/mcp-server/src/__tests__/utils/mock-logger.ts
+++ b/mcp-server/src/__tests__/utils/mock-logger.ts
@@ -1,0 +1,49 @@
+import { vi } from 'vitest';
+
+export interface MockLogger {
+  log: ReturnType<typeof vi.fn>;
+  info: ReturnType<typeof vi.fn>;
+  warn: ReturnType<typeof vi.fn>;
+  error: ReturnType<typeof vi.fn>;
+  debug: ReturnType<typeof vi.fn>;
+}
+
+export function createMockLogger(): MockLogger {
+  return {
+    log: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn()
+  };
+}
+
+export function setupConsoleSpies() {
+  const originalConsole = {
+    log: console.log,
+    info: console.info,
+    warn: console.warn,
+    error: console.error,
+    debug: console.debug
+  };
+
+  const mockLogger = createMockLogger();
+  
+  beforeAll(() => {
+    console.log = mockLogger.log;
+    console.info = mockLogger.info;
+    console.warn = mockLogger.warn;
+    console.error = mockLogger.error;
+    console.debug = mockLogger.debug;
+  });
+
+  afterAll(() => {
+    console.log = originalConsole.log;
+    console.info = originalConsole.info;
+    console.warn = originalConsole.warn;
+    console.error = originalConsole.error;
+    console.debug = originalConsole.debug;
+  });
+
+  return mockLogger;
+}

--- a/mcp-server/src/__tests__/utils/test-database.ts
+++ b/mcp-server/src/__tests__/utils/test-database.ts
@@ -1,0 +1,87 @@
+import Database from 'better-sqlite3';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+export function createTestDatabase(): Database.Database {
+  // Create in-memory database for testing
+  const db = new Database(':memory:');
+  
+  // Initialize schema from the SQL file
+  const schemaPath = join(__dirname, '../../tools/activity-logger/schema.sql');
+  const schema = readFileSync(schemaPath, 'utf-8');
+  
+  db.exec(schema);
+  
+  return db;
+}
+
+export function seedTestDatabase(db: Database.Database): void {
+  const insertActivity = db.prepare(`
+    INSERT INTO activities (
+      tool_name, activity, activity_type, tags, 
+      success, error, context, files_affected, 
+      issue_number, link
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `);
+
+  // Seed with sample activities
+  const sampleActivities = [
+    {
+      tool_name: 'test-tool',
+      activity: 'Created test file for authentication module',
+      activity_type: 'create',
+      tags: JSON.stringify(['testing', 'authentication']),
+      success: 1,
+      error: null,
+      context: JSON.stringify({ test: true }),
+      files_affected: JSON.stringify(['src/auth/auth.test.ts']),
+      issue_number: 123,
+      link: 'https://github.com/test/test/issues/123'
+    },
+    {
+      tool_name: 'test-tool',
+      activity: 'Fixed bug in user validation',
+      activity_type: 'fix',
+      tags: JSON.stringify(['bug-fix', 'validation']),
+      success: 1,
+      error: null,
+      context: null,
+      files_affected: JSON.stringify(['src/validation/user.ts']),
+      issue_number: null,
+      link: null
+    },
+    {
+      tool_name: 'test-tool',
+      activity: 'Failed to update configuration',
+      activity_type: 'update',
+      tags: JSON.stringify(['configuration']),
+      success: 0,
+      error: 'Permission denied',
+      context: null,
+      files_affected: null,
+      issue_number: null,
+      link: null
+    }
+  ];
+
+  sampleActivities.forEach(activity => {
+    insertActivity.run(
+      activity.tool_name,
+      activity.activity,
+      activity.activity_type,
+      activity.tags,
+      activity.success,
+      activity.error,
+      activity.context,
+      activity.files_affected,
+      activity.issue_number,
+      activity.link
+    );
+  });
+}
+
+export function cleanupTestDatabase(db: Database.Database): void {
+  if (db && !db.closed) {
+    db.close();
+  }
+}

--- a/mcp-server/src/config/__tests__/loader.test.ts
+++ b/mcp-server/src/config/__tests__/loader.test.ts
@@ -1,0 +1,547 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { ConfigLoader } from '../loader.js';
+import { ProjectConfig } from '../types.js';
+import yaml from 'js-yaml';
+import { existsSync } from 'fs';
+
+// Mock dependencies
+vi.mock('fs', () => ({
+  existsSync: vi.fn(),
+  readFileSync: vi.fn()
+}));
+
+vi.mock('../utils/logger.js', () => ({
+  logError: vi.fn()
+}));
+
+describe('ConfigLoader', () => {
+  let configLoader: ConfigLoader;
+  let mockReadFile: ReturnType<typeof vi.fn>;
+  const testProjectPath = '/test/project';
+  const expectedConfigPath = '/test/project/.simone/project.yaml';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockReadFile = vi.fn();
+    configLoader = new ConfigLoader(testProjectPath, mockReadFile);
+  });
+
+  describe('load', () => {
+    it('should return default config when config file does not exist', () => {
+      vi.mocked(existsSync).mockReturnValue(false);
+
+      const config = configLoader.load();
+
+      expect(config).toEqual({
+        project: {
+          name: 'project',
+          type: 'single'
+        },
+        contexts: [
+          {
+            name: 'main',
+            path: './',
+            stack: {
+              language: 'unknown'
+            },
+            tooling: {}
+          }
+        ]
+      });
+      expect(mockReadFile).not.toHaveBeenCalled();
+    });
+
+    it('should load and validate valid configuration', () => {
+      const validConfig: ProjectConfig = {
+        project: {
+          name: 'test-project',
+          description: 'A test project',
+          type: 'monorepo',
+          version: '1.0.0'
+        },
+        contexts: [
+          {
+            name: 'backend',
+            path: './backend',
+            stack: {
+              language: 'TypeScript',
+              framework: {
+                enabled: true,
+                name: 'Express'
+              }
+            }
+          },
+          {
+            name: 'frontend',
+            path: './frontend',
+            stack: {
+              language: 'TypeScript',
+              framework: {
+                enabled: true,
+                name: 'React'
+              }
+            }
+          }
+        ]
+      };
+
+      vi.mocked(existsSync).mockReturnValue(true);
+      mockReadFile.mockReturnValue(yaml.dump(validConfig));
+
+      const config = configLoader.load();
+
+      expect(config).toEqual(validConfig);
+      expect(mockReadFile).toHaveBeenCalledWith(expectedConfigPath, 'utf8');
+    });
+
+    it('should throw error for missing project.name', () => {
+      const invalidConfig = {
+        project: {
+          description: 'Missing name'
+        },
+        contexts: []
+      };
+
+      vi.mocked(existsSync).mockReturnValue(true);
+      mockReadFile.mockReturnValue(yaml.dump(invalidConfig));
+
+      const config = configLoader.load();
+      
+      // Should return default config on validation error
+      expect(config).toMatchObject({
+        project: {
+          name: 'project',
+          type: 'single'
+        }
+      });
+    });
+
+    it('should throw error for missing contexts array', () => {
+      const invalidConfig = {
+        project: {
+          name: 'test-project'
+        }
+      };
+
+      vi.mocked(existsSync).mockReturnValue(true);
+      mockReadFile.mockReturnValue(yaml.dump(invalidConfig));
+
+      const config = configLoader.load();
+      
+      // Should return default config on validation error
+      expect(config).toMatchObject({
+        project: {
+          name: 'project',
+          type: 'single'
+        }
+      });
+    });
+
+    it('should validate context required fields', () => {
+      const invalidConfig = {
+        project: {
+          name: 'test-project'
+        },
+        contexts: [
+          {
+            path: './src' // Missing name
+          }
+        ]
+      };
+
+      vi.mocked(existsSync).mockReturnValue(true);
+      mockReadFile.mockReturnValue(yaml.dump(invalidConfig));
+
+      const config = configLoader.load();
+      
+      // Should return default config on validation error
+      expect(config).toMatchObject({
+        project: {
+          name: 'project',
+          type: 'single'
+        }
+      });
+    });
+
+    it('should handle YAML parsing errors gracefully', () => {
+      const invalidYaml = `
+project:
+  name: test
+  [invalid yaml
+contexts:
+  - name: main
+`;
+
+      vi.mocked(existsSync).mockReturnValue(true);
+      mockReadFile.mockReturnValue(invalidYaml);
+
+      const config = configLoader.load();
+      
+      // Should return default config on error
+      expect(config).toMatchObject({
+        project: {
+          name: 'project',
+          type: 'single'
+        }
+      });
+    });
+
+    it('should handle file read errors gracefully', () => {
+      vi.mocked(existsSync).mockReturnValue(true);
+      mockReadFile.mockImplementation(() => {
+        throw new Error('Permission denied');
+      });
+
+      const config = configLoader.load();
+      
+      // Should return default config on error
+      expect(config).toMatchObject({
+        project: {
+          name: 'project',
+          type: 'single'
+        }
+      });
+    });
+  });
+
+  describe('getConfig', () => {
+    it('should lazy load configuration on first access', () => {
+      const validConfig: ProjectConfig = {
+        project: {
+          name: 'test-project'
+        },
+        contexts: [
+          {
+            name: 'main',
+            path: './'
+          }
+        ]
+      };
+
+      vi.mocked(existsSync).mockReturnValue(true);
+      mockReadFile.mockReturnValue(yaml.dump(validConfig));
+
+      // First call should trigger load
+      const config1 = configLoader.getConfig();
+      expect(mockReadFile).toHaveBeenCalledTimes(1);
+
+      // Second call should use cached value
+      const config2 = configLoader.getConfig();
+      expect(mockReadFile).toHaveBeenCalledTimes(1); // Still only 1 call
+      expect(config1).toBe(config2);
+    });
+  });
+
+  describe('getResolvedContexts', () => {
+    it('should merge shared tooling with context tooling', () => {
+      const config: ProjectConfig = {
+        project: {
+          name: 'test-project'
+        },
+        shared: {
+          tooling: {
+            lint: {
+              enabled: true,
+              command: 'eslint .'
+            },
+            format: {
+              enabled: true,
+              command: 'prettier --write .'
+            }
+          }
+        },
+        contexts: [
+          {
+            name: 'backend',
+            path: './backend',
+            tooling: {
+              lint: {
+                enabled: true,
+                command: 'eslint src/', // Override
+                autofix: 'eslint src/ --fix'
+              },
+              test: {
+                enabled: true,
+                command: 'jest'
+              }
+            }
+          }
+        ]
+      };
+
+      vi.mocked(existsSync).mockReturnValue(true);
+      mockReadFile.mockReturnValue(yaml.dump(config));
+      configLoader.load();
+
+      const contexts = configLoader.getResolvedContexts();
+
+      expect(contexts[0].resolvedTooling).toEqual({
+        format: {
+          enabled: true,
+          command: 'prettier --write .'
+        },
+        lint: {
+          enabled: true,
+          command: 'eslint src/',
+          autofix: 'eslint src/ --fix'
+        },
+        test: {
+          enabled: true,
+          command: 'jest'
+        }
+      });
+    });
+
+    it('should merge shared methodology with context methodology', () => {
+      const config: ProjectConfig = {
+        project: {
+          name: 'test-project'
+        },
+        shared: {
+          methodology: {
+            development: 'tdd',
+            workflow: 'gitflow'
+          }
+        },
+        contexts: [
+          {
+            name: 'microservice',
+            path: './service',
+            methodology: {
+              architecture: 'microservices',
+              workflow: 'trunk-based' // Override
+            }
+          }
+        ]
+      };
+
+      vi.mocked(existsSync).mockReturnValue(true);
+      mockReadFile.mockReturnValue(yaml.dump(config));
+      configLoader.load();
+
+      const contexts = configLoader.getResolvedContexts();
+
+      expect(contexts[0].resolvedMethodology).toEqual({
+        development: 'tdd',
+        workflow: 'trunk-based',
+        architecture: 'microservices'
+      });
+    });
+
+    it('should handle contexts without shared config', () => {
+      const config: ProjectConfig = {
+        project: {
+          name: 'test-project'
+        },
+        contexts: [
+          {
+            name: 'simple',
+            path: './',
+            tooling: {
+              lint: {
+                enabled: true,
+                command: 'eslint .'
+              }
+            }
+          }
+        ]
+      };
+
+      vi.mocked(existsSync).mockReturnValue(true);
+      mockReadFile.mockReturnValue(yaml.dump(config));
+      configLoader.load();
+
+      const contexts = configLoader.getResolvedContexts();
+
+      expect(contexts[0].resolvedTooling).toEqual({
+        lint: {
+          enabled: true,
+          command: 'eslint .'
+        }
+      });
+    });
+  });
+
+  describe('isFeatureEnabled', () => {
+    it('should return true when feature is enabled in any context', () => {
+      const config: ProjectConfig = {
+        project: {
+          name: 'test-project'
+        },
+        contexts: [
+          {
+            name: 'context1',
+            path: './c1',
+            tooling: {
+              lint: {
+                enabled: false
+              }
+            }
+          },
+          {
+            name: 'context2',
+            path: './c2',
+            tooling: {
+              lint: {
+                enabled: true
+              }
+            }
+          }
+        ]
+      };
+
+      vi.mocked(existsSync).mockReturnValue(true);
+      mockReadFile.mockReturnValue(yaml.dump(config));
+      configLoader.load();
+
+      expect(configLoader.isFeatureEnabled('tooling.lint')).toBe(true);
+    });
+
+    it('should return false when feature is disabled in all contexts', () => {
+      const config: ProjectConfig = {
+        project: {
+          name: 'test-project'
+        },
+        contexts: [
+          {
+            name: 'context1',
+            path: './c1',
+            tooling: {
+              lint: {
+                enabled: false
+              }
+            }
+          },
+          {
+            name: 'context2',
+            path: './c2',
+            tooling: {
+              lint: {
+                enabled: false
+              }
+            }
+          }
+        ]
+      };
+
+      vi.mocked(existsSync).mockReturnValue(true);
+      mockReadFile.mockReturnValue(yaml.dump(config));
+      configLoader.load();
+
+      expect(configLoader.isFeatureEnabled('tooling.lint')).toBe(false);
+    });
+
+    it('should handle nested feature paths', () => {
+      const config: ProjectConfig = {
+        project: {
+          name: 'test-project'
+        },
+        contexts: [
+          {
+            name: 'main',
+            path: './',
+            stack: {
+              framework: {
+                enabled: true,
+                name: 'Express'
+              }
+            }
+          }
+        ]
+      };
+
+      vi.mocked(existsSync).mockReturnValue(true);
+      mockReadFile.mockReturnValue(yaml.dump(config));
+      configLoader.load();
+
+      expect(configLoader.isFeatureEnabled('stack.framework')).toBe(true);
+    });
+
+    it('should use resolved values when checking shared config', () => {
+      const config: ProjectConfig = {
+        project: {
+          name: 'test-project'
+        },
+        shared: {
+          tooling: {
+            test: {
+              enabled: true
+            }
+          }
+        },
+        contexts: [
+          {
+            name: 'main',
+            path: './'
+          }
+        ]
+      };
+
+      vi.mocked(existsSync).mockReturnValue(true);
+      mockReadFile.mockReturnValue(yaml.dump(config));
+      configLoader.load();
+
+      expect(configLoader.isFeatureEnabled('tooling.test')).toBe(true);
+    });
+
+    it('should return false for non-existent feature paths', () => {
+      const config: ProjectConfig = {
+        project: {
+          name: 'test-project'
+        },
+        contexts: [
+          {
+            name: 'main',
+            path: './'
+          }
+        ]
+      };
+
+      vi.mocked(existsSync).mockReturnValue(true);
+      mockReadFile.mockReturnValue(yaml.dump(config));
+      configLoader.load();
+
+      expect(configLoader.isFeatureEnabled('nonexistent.feature')).toBe(false);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle empty project path gracefully', () => {
+      const loader = new ConfigLoader('', mockReadFile);
+      vi.mocked(existsSync).mockReturnValue(false);
+
+      const config = loader.load();
+
+      expect(config).toMatchObject({
+        project: {
+          name: 'unnamed-project'
+        }
+      });
+    });
+
+    it('should support custom properties in configuration', () => {
+      const config: ProjectConfig = {
+        project: {
+          name: 'test-project',
+          customField: 'custom value'
+        } as any,
+        contexts: [
+          {
+            name: 'main',
+            path: './',
+            customContext: {
+              nested: 'value'
+            }
+          }
+        ]
+      };
+
+      vi.mocked(existsSync).mockReturnValue(true);
+      mockReadFile.mockReturnValue(yaml.dump(config));
+
+      const loaded = configLoader.load();
+
+      expect(loaded).toEqual(config);
+    });
+  });
+});

--- a/mcp-server/src/config/types.ts
+++ b/mcp-server/src/config/types.ts
@@ -119,8 +119,21 @@ export interface GitHubConfig {
   repository: string;  // owner/repo format
   tool?: 'mcp' | 'cli';  // default to 'cli' if not specified
   defaultLabels?: string[];  // labels to apply to new issues
+  github_projects?: GitHubProjectsConfig;  // optional GitHub Projects integration
   // Allow custom GitHub properties
   [key: string]: any;
+}
+
+/**
+ * GitHub Projects integration configuration
+ */
+export interface GitHubProjectsConfig {
+  enabled: boolean;           // whether Projects integration is enabled
+  project_id: string;         // GitHub Project ID
+  idea_status: string;        // status for draft/idea items
+  work_status: string;        // status for items to pull from work queue
+  new_issue_status: string;   // status for newly created issues
+  available_statuses?: string[];  // cached list of available statuses
 }
 
 /**

--- a/mcp-server/src/templates/__tests__/context.test.ts
+++ b/mcp-server/src/templates/__tests__/context.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { buildTemplateContext } from '../context.js';
+
+describe('buildTemplateContext', () => {
+  let mockDate: Date;
+
+  beforeEach(() => {
+    // Mock Date to have consistent test results
+    mockDate = new Date('2024-01-15T14:30:45.123Z');
+    vi.useFakeTimers();
+    vi.setSystemTime(mockDate);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should create base context with project information', () => {
+    const projectPath = '/home/user/projects/my-app';
+    const context = buildTemplateContext(projectPath);
+
+    expect(context).toMatchObject({
+      PROJECT_PATH: projectPath,
+      PROJECT_NAME: 'my-app',
+      TIMESTAMP: '2024-01-15T14:30:45.123Z',
+      CURRENT_DATE: expect.any(String),
+      CURRENT_TIME: expect.any(String)
+    });
+  });
+
+  it('should handle edge cases for project name extraction', () => {
+    const testCases = [
+      { path: '/simple/path', expected: 'path' },
+      { path: '/path/with/trailing/', expected: 'trailing' }, // basename strips trailing slash
+      { path: '/', expected: '' }, // basename of root is empty
+      { path: '', expected: '' }, // basename of empty string is empty
+      { path: 'relative/path', expected: 'path' },
+      { path: './current', expected: 'current' },
+      { path: '/path/with spaces/project', expected: 'project' },
+      { path: '/path/with-dashes', expected: 'with-dashes' },
+      { path: '/path/with_underscores', expected: 'with_underscores' }
+    ];
+
+    testCases.forEach(({ path, expected }) => {
+      const context = buildTemplateContext(path);
+      expect(context.PROJECT_NAME).toBe(expected);
+    });
+  });
+
+  it('should merge additional arguments into context', () => {
+    const projectPath = '/test/project';
+    const additionalArgs = {
+      customField: 'custom value',
+      numberField: 42,
+      booleanField: true,
+      objectField: { nested: 'value' },
+      arrayField: ['item1', 'item2']
+    };
+
+    const context = buildTemplateContext(projectPath, additionalArgs);
+
+    expect(context).toMatchObject({
+      PROJECT_PATH: projectPath,
+      PROJECT_NAME: 'project',
+      ...additionalArgs
+    });
+  });
+
+  it('should allow additional args to override base fields', () => {
+    const projectPath = '/test/project';
+    const additionalArgs = {
+      PROJECT_PATH: '/different/path',
+      PROJECT_NAME: 'different-name',
+      TIMESTAMP: 'different-timestamp',
+      CURRENT_DATE: 'different-date',
+      CURRENT_TIME: 'different-time',
+      customField: 'allowed'
+    };
+
+    const context = buildTemplateContext(projectPath, additionalArgs);
+
+    // Additional args override base fields (due to spread operator)
+    expect(context.PROJECT_PATH).toBe('/different/path');
+    expect(context.PROJECT_NAME).toBe('different-name');
+    expect(context.TIMESTAMP).toBe('different-timestamp');
+    expect(context.CURRENT_DATE).toBe('different-date');
+    expect(context.CURRENT_TIME).toBe('different-time');
+    
+    // Additional fields should be included
+    expect(context.customField).toBe('allowed');
+  });
+
+  it('should handle null and undefined additional arguments', () => {
+    const projectPath = '/test/project';
+
+    const contextWithNull = buildTemplateContext(projectPath, null as any);
+    expect(contextWithNull).toMatchObject({
+      PROJECT_PATH: projectPath,
+      PROJECT_NAME: 'project'
+    });
+
+    const contextWithUndefined = buildTemplateContext(projectPath, undefined);
+    expect(contextWithUndefined).toMatchObject({
+      PROJECT_PATH: projectPath,
+      PROJECT_NAME: 'project'
+    });
+  });
+
+  it('should format dates and times in locale format', () => {
+    const projectPath = '/test/project';
+    const context = buildTemplateContext(projectPath);
+
+    // These will vary by locale, so just verify they're strings
+    expect(typeof context.CURRENT_DATE).toBe('string');
+    expect(typeof context.CURRENT_TIME).toBe('string');
+    expect(context.CURRENT_DATE.length).toBeGreaterThan(0);
+    expect(context.CURRENT_TIME.length).toBeGreaterThan(0);
+  });
+
+  it('should handle complex project paths', () => {
+    const complexPaths = [
+      { 
+        path: '/Users/john.doe/Documents/Work Projects/2024/my-project',
+        expected: 'my-project'
+      },
+      {
+        // Node's basename handles Windows paths differently on Unix systems
+        path: '\\\\network\\share\\projects\\app',
+        expected: '\\\\network\\share\\projects\\app' // basename doesn't split on backslash on Unix
+      },
+      {
+        path: '../../../relative/project',
+        expected: 'project'
+      }
+    ];
+
+    complexPaths.forEach(({ path, expected }) => {
+      const context = buildTemplateContext(path);
+      expect(context.PROJECT_NAME).toBe(expected);
+    });
+  });
+
+  it('should preserve additional argument types', () => {
+    const projectPath = '/test/project';
+    const complexArgs = {
+      stringValue: 'test',
+      numberValue: 123.45,
+      booleanValue: false,
+      nullValue: null,
+      undefinedValue: undefined,
+      dateValue: new Date('2024-01-01'),
+      regexValue: /test/gi,
+      functionValue: () => 'test',
+      symbolValue: Symbol('test')
+    };
+
+    const context = buildTemplateContext(projectPath, complexArgs);
+
+    // Verify types are preserved
+    expect(typeof context.stringValue).toBe('string');
+    expect(typeof context.numberValue).toBe('number');
+    expect(typeof context.booleanValue).toBe('boolean');
+    expect(context.nullValue).toBeNull();
+    expect(context.undefinedValue).toBeUndefined();
+    expect(context.dateValue).toBeInstanceOf(Date);
+    expect(context.regexValue).toBeInstanceOf(RegExp);
+    expect(typeof context.functionValue).toBe('function');
+    expect(typeof context.symbolValue).toBe('symbol');
+  });
+
+  it('should create consistent timestamps', () => {
+    const projectPath = '/test/project';
+    
+    const context1 = buildTemplateContext(projectPath);
+    const context2 = buildTemplateContext(projectPath);
+
+    // Both should have the same timestamp since we're using fake timers
+    expect(context1.TIMESTAMP).toBe(context2.TIMESTAMP);
+    expect(context1.TIMESTAMP).toBe('2024-01-15T14:30:45.123Z');
+  });
+});

--- a/mcp-server/src/templates/__tests__/handler.test.ts
+++ b/mcp-server/src/templates/__tests__/handler.test.ts
@@ -1,0 +1,378 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { PromptHandler } from '../handler.js';
+import { TemplateLoader } from '../loader.js';
+import { ConfigLoader } from '../../config/loader.js';
+import { buildTemplateContext } from '../context.js';
+import { PromptMessage } from '@modelcontextprotocol/sdk/types.js';
+import { existsSync } from 'fs';
+import { readFile } from 'fs/promises';
+
+// Mock dependencies
+vi.mock('../loader.js');
+vi.mock('../../config/loader.js');
+vi.mock('../context.js');
+vi.mock('fs');
+vi.mock('fs/promises');
+vi.mock('../../utils/logger.js', () => ({
+  logError: vi.fn()
+}));
+
+describe('PromptHandler', () => {
+  let promptHandler: PromptHandler;
+  let mockTemplateLoader: any;
+  let mockConfigLoader: any;
+  const projectPath = '/test/project';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Setup mocks
+    mockTemplateLoader = {
+      loadPrompt: vi.fn(),
+      loadPartials: vi.fn().mockReturnValue({}),
+      compileTemplate: vi.fn(),
+      listAvailablePrompts: vi.fn()
+    };
+
+    mockConfigLoader = {
+      getConfig: vi.fn().mockReturnValue({
+        project: { name: 'test-project' },
+        contexts: []
+      }),
+      getResolvedContexts: vi.fn().mockReturnValue([])
+    };
+
+    vi.mocked(TemplateLoader).mockReturnValue(mockTemplateLoader);
+    vi.mocked(ConfigLoader).mockReturnValue(mockConfigLoader);
+    vi.mocked(buildTemplateContext).mockReturnValue({
+      PROJECT_PATH: projectPath,
+      PROJECT_NAME: 'test-project',
+      TIMESTAMP: '2024-01-01T00:00:00.000Z',
+      CURRENT_DATE: '1/1/2024',
+      CURRENT_TIME: '12:00:00 AM'
+    });
+
+    promptHandler = new PromptHandler(projectPath);
+  });
+
+  describe('getPromptMessages', () => {
+    it('should render a simple prompt without arguments', async () => {
+      const mockPrompt = {
+        name: 'simple',
+        description: 'Simple prompt',
+        template: 'Hello from {{PROJECT_NAME}}!'
+      };
+
+      const mockCompiled = vi.fn().mockReturnValue('Hello from test-project!');
+
+      mockTemplateLoader.loadPrompt.mockReturnValue(mockPrompt);
+      mockTemplateLoader.compileTemplate.mockReturnValue(mockCompiled);
+
+      const result = await promptHandler.getPromptMessages({ name: 'simple' });
+
+      expect(result).toEqual([
+        {
+          role: 'user',
+          content: {
+            type: 'text',
+            text: 'Hello from test-project!'
+          }
+        }
+      ]);
+    });
+
+    it('should render prompt with arguments and defaults', async () => {
+      const mockPrompt = {
+        name: 'with_args',
+        description: 'Prompt with arguments',
+        arguments: [
+          {
+            name: 'required_arg',
+            description: 'Required argument',
+            required: true
+          },
+          {
+            name: 'optional_arg',
+            description: 'Optional argument',
+            required: false,
+            default: 'default_value'
+          },
+          {
+            name: 'dynamic_default',
+            description: 'Dynamic default',
+            required: false,
+            default: '{{PROJECT_NAME}}-suffix'
+          }
+        ],
+        template: 'Required: {{required_arg}}, Optional: {{optional_arg}}, Dynamic: {{dynamic_default}}'
+      };
+
+      // Mock for default value compilation
+      const defaultValueCompiler = vi.fn().mockReturnValue('default_value');
+      const dynamicDefaultCompiler = vi.fn().mockReturnValue('test-project-suffix');
+      const mainTemplateCompiler = vi.fn().mockReturnValue(
+        'Required: provided, Optional: default_value, Dynamic: test-project-suffix'
+      );
+
+      mockTemplateLoader.loadPrompt.mockReturnValue(mockPrompt);
+      mockTemplateLoader.compileTemplate
+        .mockReturnValueOnce(defaultValueCompiler) // For 'default_value'
+        .mockReturnValueOnce(dynamicDefaultCompiler) // For '{{PROJECT_NAME}}-suffix'
+        .mockReturnValueOnce(mainTemplateCompiler); // For main template
+
+      const result = await promptHandler.getPromptMessages({
+        name: 'with_args',
+        arguments: { required_arg: 'provided' }
+      });
+
+      expect(result[0].content.text).toBe(
+        'Required: provided, Optional: default_value, Dynamic: test-project-suffix'
+      );
+    });
+
+    it('should auto-load constitution when it exists', async () => {
+      const mockPrompt = {
+        name: 'with_constitution',
+        description: 'Prompt using constitution',
+        template: 'Constitution: {{constitution}}'
+      };
+
+      const mockConstitution = '# Project Constitution\nProject rules...';
+      vi.mocked(existsSync).mockImplementation((path) => {
+        return path.toString().includes('constitution.md');
+      });
+      vi.mocked(readFile).mockResolvedValue(mockConstitution);
+
+      mockTemplateLoader.loadPrompt.mockReturnValue(mockPrompt);
+      mockTemplateLoader.compileTemplate.mockReturnValue(
+        vi.fn().mockReturnValue('Constitution: # Project Constitution\nProject rules...')
+      );
+
+      const result = await promptHandler.getPromptMessages({ name: 'with_constitution' });
+
+      expect(result[0].content.text).toBe('Constitution: # Project Constitution\nProject rules...');
+      expect(readFile).toHaveBeenCalledWith(
+        expect.stringContaining('constitution.md'),
+        'utf8'
+      );
+    });
+
+    it('should handle missing constitution gracefully', async () => {
+      const mockPrompt = {
+        name: 'simple',
+        description: 'Simple prompt',
+        template: 'Template without constitution'
+      };
+
+      vi.mocked(existsSync).mockReturnValue(false);
+
+      mockTemplateLoader.loadPrompt.mockReturnValue(mockPrompt);
+      mockTemplateLoader.compileTemplate.mockReturnValue(
+        vi.fn().mockReturnValue('Template without constitution')
+      );
+
+      const result = await promptHandler.getPromptMessages({ name: 'simple' });
+
+      // Should not error when constitution doesn't exist
+      expect(result[0].content.text).toBe('Template without constitution');
+    });
+
+    it('should handle constitution read errors', async () => {
+      const mockPrompt = {
+        name: 'test',
+        description: 'Test prompt',
+        template: 'Test'
+      };
+
+      vi.mocked(existsSync).mockImplementation((path) => {
+        return path.toString().includes('constitution.md');
+      });
+      vi.mocked(readFile).mockRejectedValue(new Error('Permission denied'));
+
+      mockTemplateLoader.loadPrompt.mockReturnValue(mockPrompt);
+
+      const result = await promptHandler.getPromptMessages({ name: 'test' });
+
+      expect(result[0].content.text).toContain('Failed to read constitution.md');
+      expect(result[0].content.text).toContain('Permission denied');
+    });
+
+    it('should handle template loading errors', async () => {
+      vi.mocked(existsSync).mockReturnValue(false);
+
+      mockTemplateLoader.loadPrompt.mockReturnValue({
+        name: 'error',
+        template: 'Error: Template not found'
+      });
+      mockTemplateLoader.compileTemplate.mockReturnValue(
+        vi.fn().mockReturnValue('Error: Template not found')
+      );
+
+      const result = await promptHandler.getPromptMessages({ name: 'nonexistent' });
+
+      expect(result[0].content.text).toBe('Error: Template not found');
+    });
+
+    it('should include project configuration in context', async () => {
+      const mockConfig = {
+        project: {
+          name: 'configured-project',
+          description: 'Test project'
+        },
+        contexts: [
+          {
+            name: 'backend',
+            path: './backend'
+          }
+        ],
+        github: {
+          repository: 'owner/repo'
+        }
+      };
+
+      mockConfigLoader.getConfig.mockReturnValue(mockConfig);
+
+      const mockPrompt = {
+        name: 'config_test',
+        template: 'Project: {{project.name}}, GitHub: {{github.repository}}'
+      };
+
+      vi.mocked(existsSync).mockReturnValue(false);
+
+      mockTemplateLoader.loadPrompt.mockReturnValue(mockPrompt);
+      
+      let capturedContext: any = null;
+      mockTemplateLoader.compileTemplate.mockReturnValue(
+        vi.fn().mockImplementation((context) => {
+          capturedContext = context;
+          return 'Project: configured-project, GitHub: owner/repo';
+        })
+      );
+
+      await promptHandler.getPromptMessages({ name: 'config_test' });
+
+      expect(capturedContext).toMatchObject({
+        project: mockConfig.project,
+        contexts: mockConfig.contexts,
+        github: mockConfig.github
+      });
+      expect(mockTemplateLoader.compileTemplate).toHaveBeenCalled();
+    });
+
+    it('should validate required arguments', async () => {
+      const mockPrompt = {
+        name: 'requires_args',
+        arguments: [
+          {
+            name: 'required1',
+            required: true
+          },
+          {
+            name: 'required2',
+            required: true
+          }
+        ],
+        template: 'Test'
+      };
+
+      mockTemplateLoader.loadPrompt.mockReturnValue(mockPrompt);
+      mockTemplateLoader.compileTemplate.mockReturnValue(vi.fn().mockReturnValue('Test'));
+
+      vi.mocked(existsSync).mockReturnValue(false);
+
+      // Missing required arguments should still render (with undefined values)
+      const result = await promptHandler.getPromptMessages({
+        name: 'requires_args',
+        arguments: { required1: 'provided' }
+      });
+
+      expect(result[0].content.text).toBe('Test');
+      expect(mockTemplateLoader.compileTemplate).toHaveBeenCalled();
+    });
+  });
+
+  describe('listAvailablePrompts', () => {
+    it('should scan directories and load prompts', async () => {
+      // Mock readdir to return prompt files
+      const mockReaddir = vi.fn()
+        .mockResolvedValueOnce(['prompt1.yaml', 'prompt2.yml'])
+        .mockResolvedValueOnce(['builtin1.yaml', 'error.yaml']);
+
+      vi.doMock('fs/promises', () => ({
+        readdir: mockReaddir
+      }));
+
+      const mockPrompts = [
+        { name: 'prompt1', template: 'Test 1' },
+        { name: 'prompt2', template: 'Test 2' },
+        { name: 'builtin1', template: 'Built-in 1' },
+        { name: 'error', template: 'Error template' }
+      ];
+
+      mockTemplateLoader.loadPrompt
+        .mockResolvedValueOnce(mockPrompts[0])
+        .mockResolvedValueOnce(mockPrompts[1])
+        .mockResolvedValueOnce(mockPrompts[2])
+        .mockResolvedValueOnce(mockPrompts[3]);
+
+      const result = await promptHandler.listAvailablePrompts();
+
+      // Should not include error template
+      expect(result).toHaveLength(3);
+      expect(result).toEqual([
+        mockPrompts[0],
+        mockPrompts[1],
+        mockPrompts[2]
+      ]);
+    });
+  });
+
+  describe('helper registration', () => {
+    it('should register comparison helpers on construction', () => {
+      // This is tested implicitly by the constructor
+      // Helpers are registered in the constructor
+      expect(promptHandler).toBeDefined();
+    });
+  });
+
+  describe('context merging', () => {
+    it('should merge all context sources in correct order', async () => {
+      const baseContext = {
+        PROJECT_PATH: projectPath,
+        PROJECT_NAME: 'base-name'
+      };
+
+      const configData = {
+        project: { name: 'config-name' }
+      };
+
+      const userArgs = {
+        PROJECT_NAME: 'user-override',
+        custom_arg: 'custom_value'
+      };
+
+      vi.mocked(buildTemplateContext).mockReturnValue(baseContext);
+      mockConfigLoader.getConfig.mockReturnValue(configData);
+
+      const mockPrompt = {
+        name: 'merge_test',
+        template: 'Name: {{PROJECT_NAME}}, Custom: {{custom_arg}}'
+      };
+
+      mockTemplateLoader.loadPrompt.mockReturnValue(mockPrompt);
+      mockTemplateLoader.compileTemplate.mockReturnValue(
+        vi.fn().mockImplementation((context) => {
+          // Verify merging order: base < config < defaults < user
+          expect(context.PROJECT_NAME).toBe('user-override');
+          expect(context.custom_arg).toBe('custom_value');
+          return 'Name: user-override, Custom: custom_value';
+        })
+      );
+
+      await promptHandler.getPromptMessages({
+        name: 'merge_test',
+        arguments: userArgs
+      });
+    });
+  });
+});

--- a/mcp-server/src/templates/__tests__/helpers.test.ts
+++ b/mcp-server/src/templates/__tests__/helpers.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import Handlebars from 'handlebars';
+import { registerHelpers } from '../helpers/index.js';
+
+describe('Handlebars Helpers', () => {
+  beforeEach(() => {
+    // Register helpers on the global Handlebars instance
+    registerHelpers();
+  });
+
+  describe('eq (equality) helper', () => {
+    it('should return true for equal values', () => {
+      const template = Handlebars.compile('{{#if (eq a b)}}equal{{else}}not equal{{/if}}');
+      
+      expect(template({ a: 5, b: 5 })).toBe('equal');
+      expect(template({ a: 'test', b: 'test' })).toBe('equal');
+      expect(template({ a: true, b: true })).toBe('equal');
+      expect(template({ a: null, b: null })).toBe('equal');
+    });
+
+    it('should return false for different values', () => {
+      const template = Handlebars.compile('{{#if (eq a b)}}equal{{else}}not equal{{/if}}');
+      
+      expect(template({ a: 5, b: 10 })).toBe('not equal');
+      expect(template({ a: 'test', b: 'other' })).toBe('not equal');
+      expect(template({ a: true, b: false })).toBe('not equal');
+      expect(template({ a: null, b: undefined })).toBe('not equal');
+    });
+
+    it('should use strict equality', () => {
+      const template = Handlebars.compile('{{#if (eq a b)}}equal{{else}}not equal{{/if}}');
+      
+      expect(template({ a: 5, b: '5' })).toBe('not equal');
+      expect(template({ a: 0, b: false })).toBe('not equal');
+      expect(template({ a: '', b: false })).toBe('not equal');
+      expect(template({ a: '0', b: 0 })).toBe('not equal');
+    });
+
+    it('should work in unless blocks', () => {
+      const template = Handlebars.compile('{{#unless (eq a b)}}different{{else}}same{{/unless}}');
+      
+      expect(template({ a: 1, b: 2 })).toBe('different');
+      expect(template({ a: 1, b: 1 })).toBe('same');
+    });
+  });
+
+  describe('lt (less than) helper', () => {
+    it('should return true when first value is less than second', () => {
+      const template = Handlebars.compile('{{#if (lt a b)}}less{{else}}not less{{/if}}');
+      
+      expect(template({ a: 5, b: 10 })).toBe('less');
+      expect(template({ a: -10, b: -5 })).toBe('less');
+      expect(template({ a: 0, b: 1 })).toBe('less');
+      expect(template({ a: 'a', b: 'b' })).toBe('less');
+    });
+
+    it('should return false when first value is equal or greater', () => {
+      const template = Handlebars.compile('{{#if (lt a b)}}less{{else}}not less{{/if}}');
+      
+      expect(template({ a: 10, b: 5 })).toBe('not less');
+      expect(template({ a: 5, b: 5 })).toBe('not less');
+      expect(template({ a: 'z', b: 'a' })).toBe('not less');
+    });
+
+    it('should handle edge cases', () => {
+      const template = Handlebars.compile('{{#if (lt a b)}}less{{else}}not less{{/if}}');
+      
+      expect(template({ a: null, b: 0 })).toBe('not less');
+      expect(template({ a: undefined, b: 0 })).toBe('not less');
+      expect(template({ a: NaN, b: 5 })).toBe('not less');
+    });
+  });
+
+  describe('lte (less than or equal) helper', () => {
+    it('should return true when first value is less than or equal to second', () => {
+      const template = Handlebars.compile('{{#if (lte a b)}}true{{else}}false{{/if}}');
+      
+      expect(template({ a: 5, b: 10 })).toBe('true');
+      expect(template({ a: 10, b: 10 })).toBe('true');
+      expect(template({ a: 'a', b: 'a' })).toBe('true');
+    });
+
+    it('should return false when first value is greater', () => {
+      const template = Handlebars.compile('{{#if (lte a b)}}true{{else}}false{{/if}}');
+      
+      expect(template({ a: 15, b: 10 })).toBe('false');
+      expect(template({ a: 'z', b: 'a' })).toBe('false');
+    });
+  });
+
+  describe('gt (greater than) helper', () => {
+    it('should return true when first value is greater than second', () => {
+      const template = Handlebars.compile('{{#if (gt a b)}}greater{{else}}not greater{{/if}}');
+      
+      expect(template({ a: 10, b: 5 })).toBe('greater');
+      expect(template({ a: -5, b: -10 })).toBe('greater');
+      expect(template({ a: 'z', b: 'a' })).toBe('greater');
+    });
+
+    it('should return false when first value is equal or less', () => {
+      const template = Handlebars.compile('{{#if (gt a b)}}greater{{else}}not greater{{/if}}');
+      
+      expect(template({ a: 5, b: 10 })).toBe('not greater');
+      expect(template({ a: 5, b: 5 })).toBe('not greater');
+    });
+  });
+
+  describe('gte (greater than or equal) helper', () => {
+    it('should return true when first value is greater than or equal to second', () => {
+      const template = Handlebars.compile('{{#if (gte a b)}}true{{else}}false{{/if}}');
+      
+      expect(template({ a: 10, b: 5 })).toBe('true');
+      expect(template({ a: 5, b: 5 })).toBe('true');
+      expect(template({ a: 'z', b: 'a' })).toBe('true');
+    });
+
+    it('should return false when first value is less', () => {
+      const template = Handlebars.compile('{{#if (gte a b)}}true{{else}}false{{/if}}');
+      
+      expect(template({ a: 5, b: 10 })).toBe('false');
+      expect(template({ a: 'a', b: 'z' })).toBe('false');
+    });
+  });
+
+  describe('nested helper usage', () => {
+    it('should work with nested conditionals', () => {
+      const template = Handlebars.compile(`
+        {{#if (gt score 90)}}
+          A
+        {{else if (gte score 80)}}
+          B
+        {{else if (gte score 70)}}
+          C
+        {{else if (gte score 60)}}
+          D
+        {{else}}
+          F
+        {{/if}}
+      `);
+      
+      expect(template({ score: 95 }).trim()).toBe('A');
+      expect(template({ score: 85 }).trim()).toBe('B');
+      expect(template({ score: 75 }).trim()).toBe('C');
+      expect(template({ score: 65 }).trim()).toBe('D');
+      expect(template({ score: 55 }).trim()).toBe('F');
+    });
+
+    it('should work with complex conditions', () => {
+      const template = Handlebars.compile(`
+        {{#if (eq type "admin")}}
+          {{#if (gt level 5)}}
+            Super Admin
+          {{else}}
+            Regular Admin
+          {{/if}}
+        {{else if (eq type "user")}}
+          {{#if (gte posts 100)}}
+            Power User
+          {{else}}
+            Regular User
+          {{/if}}
+        {{else}}
+          Guest
+        {{/if}}
+      `);
+      
+      expect(template({ type: 'admin', level: 10 }).trim()).toBe('Super Admin');
+      expect(template({ type: 'admin', level: 3 }).trim()).toBe('Regular Admin');
+      expect(template({ type: 'user', posts: 150 }).trim()).toBe('Power User');
+      expect(template({ type: 'user', posts: 50 }).trim()).toBe('Regular User');
+      expect(template({ type: 'guest' }).trim()).toBe('Guest');
+    });
+  });
+
+  describe('helper with missing values', () => {
+    it('should handle undefined values gracefully', () => {
+      const template = Handlebars.compile('{{#if (eq a b)}}equal{{else}}not equal{{/if}}');
+      
+      expect(template({ a: undefined, b: undefined })).toBe('equal');
+      expect(template({ a: 5 })).toBe('not equal'); // b is undefined
+      expect(template({ b: 5 })).toBe('not equal'); // a is undefined
+    });
+
+    it('should handle comparison with undefined', () => {
+      const template = Handlebars.compile('{{#if (lt a b)}}less{{else}}not less{{/if}}');
+      
+      expect(template({ a: 5 })).toBe('not less'); // b is undefined
+      expect(template({ b: 5 })).toBe('not less'); // a is undefined
+    });
+  });
+
+  describe('helpers in different contexts', () => {
+    it('should work with array iteration', () => {
+      const template = Handlebars.compile(`
+        {{#each items}}
+          {{#if (gt value ../threshold)}}
+            {{name}}: Above
+          {{else}}
+            {{name}}: Below
+          {{/if}}
+        {{/each}}
+      `);
+      
+      const result = template({
+        threshold: 50,
+        items: [
+          { name: 'Item1', value: 60 },
+          { name: 'Item2', value: 40 },
+          { name: 'Item3', value: 70 }
+        ]
+      });
+      
+      expect(result).toContain('Item1: Above');
+      expect(result).toContain('Item2: Below');
+      expect(result).toContain('Item3: Above');
+    });
+
+    it('should access parent context in helpers', () => {
+      const template = Handlebars.compile(`
+        {{#each items}}
+          {{#if (eq type ../selectedType)}}
+            Selected: {{name}}
+          {{/if}}
+        {{/each}}
+      `);
+      
+      const result = template({
+        selectedType: 'typeA',
+        items: [
+          { name: 'Item1', type: 'typeA' },
+          { name: 'Item2', type: 'typeB' },
+          { name: 'Item3', type: 'typeA' }
+        ]
+      });
+      
+      expect(result).toContain('Selected: Item1');
+      expect(result).not.toContain('Selected: Item2');
+      expect(result).toContain('Selected: Item3');
+    });
+  });
+});

--- a/mcp-server/src/templates/__tests__/loader.test.ts
+++ b/mcp-server/src/templates/__tests__/loader.test.ts
@@ -1,0 +1,325 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { TemplateLoader } from '../loader.js';
+import { TestFixtures } from '../../__tests__/utils/fixtures.js';
+import { PromptTemplate } from '../types.js';
+import { readFileSync, statSync, readdirSync, existsSync } from 'fs';
+import { readFile, stat, readdir } from 'fs/promises';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+// Mock dependencies
+vi.mock('fs');
+vi.mock('fs/promises');
+vi.mock('../utils/logger.js', () => ({
+  logError: vi.fn()
+}));
+
+describe('TemplateLoader', () => {
+  let templateLoader: TemplateLoader;
+  const projectPath = '/test/project';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetAllMocks();
+    templateLoader = new TemplateLoader(projectPath);
+  });
+
+  describe('loadPrompt', () => {
+    const mockStat = (mtime: Date) => ({
+      mtimeMs: mtime.getTime(),
+      mtime,
+      isFile: () => true,
+      isDirectory: () => false,
+    } as any);
+
+    it('should load prompt from project directory first', async () => {
+      const testPrompt = `---
+name: test_prompt
+description: Test prompt from project
+arguments:
+  - name: testArg
+    description: Test argument
+    required: true
+template: |
+  This is a test prompt with {{testArg}}`;
+
+      const projectPromptPath = join(projectPath, '.simone/prompts/test_prompt.yaml');
+      
+      vi.mocked(existsSync)
+        .mockReturnValueOnce(true)  // project prompt exists
+        .mockReturnValueOnce(false); // built-in prompt doesn't exist
+        
+      vi.mocked(readFile).mockResolvedValue(testPrompt);
+      vi.mocked(stat).mockResolvedValue(mockStat(new Date()));
+
+      const result = await templateLoader.loadPrompt('test_prompt');
+
+      expect(result).toMatchObject({
+        name: 'test_prompt',
+        description: 'Test prompt from project',
+        arguments: [{
+          name: 'testArg',
+          description: 'Test argument',
+          required: true
+        }],
+        template: 'This is a test prompt with {{testArg}}\n'
+      });
+      expect(existsSync).toHaveBeenCalledWith(projectPromptPath);
+      expect(readFile).toHaveBeenCalledWith(projectPromptPath, 'utf-8');
+    });
+
+    it('should fallback to built-in prompt when project prompt not found', async () => {
+      const builtInPrompt = `---
+name: built_in
+description: Built-in prompt
+template: |
+  Built-in template content`;
+
+      // Reset mock and track calls
+      vi.mocked(existsSync).mockReset();
+      const existsSyncCalls: string[] = [];
+      vi.mocked(existsSync).mockImplementation((path) => {
+        const pathStr = path as string;
+        existsSyncCalls.push(pathStr);
+        // First call checks project path - return false
+        // Second call checks built-in path - return true
+        if (pathStr.includes('.simone/prompts')) {
+          return false; // project prompt doesn't exist
+        } else if (pathStr.includes('/templates/prompts')) {
+          return true;  // built-in prompt exists
+        }
+        return false;
+      });
+        
+      vi.mocked(readFile).mockResolvedValue(builtInPrompt);
+      vi.mocked(stat).mockResolvedValue(mockStat(new Date()));
+
+      const result = await templateLoader.loadPrompt('built_in');
+
+      expect(result).toMatchObject({
+        name: 'built_in',
+        description: 'Built-in prompt',
+        template: 'Built-in template content\n'
+      });
+      expect(existsSync).toHaveBeenCalledTimes(2);
+    });
+
+    it('should use cached prompt on subsequent calls', async () => {
+      const testPrompt = `---
+name: cached_prompt
+description: Cached prompt
+template: Test`;
+
+      const mtime = new Date();
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(readFile).mockResolvedValue(testPrompt);
+      vi.mocked(stat).mockResolvedValue(mockStat(mtime));
+
+      // First call - will read file and cache it
+      const result1 = await templateLoader.loadPrompt('cached_prompt');
+      expect(readFile).toHaveBeenCalledTimes(1);
+      expect(stat).toHaveBeenCalledTimes(1);
+
+      // Second call - should use cache (still checks mtime)
+      const result2 = await templateLoader.loadPrompt('cached_prompt');
+      expect(readFile).toHaveBeenCalledTimes(1); // Should not read file again
+      expect(stat).toHaveBeenCalledTimes(2); // But should check mtime
+      expect(result1).toBe(result2);
+    });
+
+    it('should invalidate cache when file is modified', async () => {
+      const originalPrompt = `---
+name: changing_prompt
+description: Original
+template: Original content`;
+
+      const updatedPrompt = `---
+name: changing_prompt
+description: Updated
+template: Updated content`;
+
+      const originalTime = new Date('2024-01-01');
+      const updatedTime = new Date('2024-01-02');
+
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(readFile)
+        .mockResolvedValueOnce(originalPrompt)
+        .mockResolvedValueOnce(updatedPrompt);
+      vi.mocked(stat)
+        .mockResolvedValueOnce(mockStat(originalTime))
+        .mockResolvedValueOnce(mockStat(updatedTime))
+        .mockResolvedValueOnce(mockStat(updatedTime));
+
+      // First call
+      const result1 = await templateLoader.loadPrompt('changing_prompt');
+      expect(result1.description).toBe('Original');
+
+      // Second call with newer mtime
+      const result2 = await templateLoader.loadPrompt('changing_prompt');
+      expect(result2.description).toBe('Updated');
+      expect(readFile).toHaveBeenCalledTimes(2);
+    });
+
+    it('should handle YAML parsing errors gracefully', async () => {
+      const invalidYaml = `---
+name: invalid
+description: [unclosed array
+template: test`;
+
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(readFile).mockResolvedValue(invalidYaml);
+      vi.mocked(stat).mockResolvedValue(mockStat(new Date()));
+
+      const result = await templateLoader.loadPrompt('invalid');
+
+      expect(result.name).toBe('error');
+      expect(result.template).toContain('Failed to parse prompt');
+      expect(result.template).toContain('invalid');
+    });
+
+    it('should handle missing template gracefully', async () => {
+      vi.mocked(existsSync).mockReturnValue(false);
+
+      const result = await templateLoader.loadPrompt('nonexistent');
+
+      expect(result).toBeNull();
+    });
+
+    it('should preserve template whitespace and formatting', async () => {
+      const complexTemplate = `---
+name: complex
+description: Complex template
+template: |
+  Line 1 with spaces    
+  Line 2 with tabs		
+  
+  Line 4 after blank line
+    Indented line`;
+
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(readFile).mockResolvedValue(complexTemplate);
+      vi.mocked(stat).mockResolvedValue(mockStat(new Date()));
+
+      const result = await templateLoader.loadPrompt('complex');
+
+      expect(result.template).toBe(
+        'Line 1 with spaces    \n' +
+        'Line 2 with tabs\t\t\n' +
+        '\n' +
+        'Line 4 after blank line\n' +
+        '  Indented line\n'
+      );
+    });
+  });
+
+  describe('loadPartial', () => {
+    it('should load a specific partial file', async () => {
+      const headerContent = '<header>{{title}}</header>';
+
+      vi.mocked(existsSync)
+        .mockReturnValueOnce(true);  // project partial exists
+      vi.mocked(readFile).mockResolvedValue(headerContent);
+
+      const partial = await templateLoader.loadPartial('header');
+
+      expect(partial).toBe(headerContent);
+      expect(readFile).toHaveBeenCalledWith(
+        join(projectPath, '.simone/prompts/partials/header.hbs'),
+        'utf-8'
+      );
+    });
+
+    it('should handle missing partial file', async () => {
+      vi.mocked(existsSync).mockReturnValue(false);
+
+      const partial = await templateLoader.loadPartial('nonexistent');
+
+      expect(partial).toBeNull();
+    });
+  });
+
+  describe('compileTemplate', () => {
+    beforeEach(() => {
+      // Mock readdir to return empty array (no partials)
+      vi.mocked(readdir).mockResolvedValue([]);
+    });
+
+    it('should compile valid Handlebars template', async () => {
+      const template = 'Hello {{name}}!';
+      const compiled = await templateLoader.compileTemplate(template);
+
+      expect(compiled({ name: 'World' })).toBe('Hello World!');
+    });
+
+    it('should cache compiled templates', async () => {
+      const template = 'Cached {{value}}';
+      
+      const compiled1 = await templateLoader.compileTemplate(template);
+      const compiled2 = await templateLoader.compileTemplate(template);
+
+      expect(compiled1).toBe(compiled2);
+    });
+
+    it('should handle runtime template errors gracefully', async () => {
+      // This template is valid during compilation but will error during execution
+      const validTemplate = '{{#if}}missing condition{{/if}}';
+      
+      const compiled = await templateLoader.compileTemplate(validTemplate);
+      
+      // The compilation should succeed
+      expect(compiled).toBeDefined();
+      expect(typeof compiled).toBe('function');
+      
+      // But execution will throw an error - let's catch it
+      expect(() => {
+        compiled({ error: 'test' });
+      }).toThrow('#if requires exactly one argument');
+    });
+
+    it('should compile templates with partials', async () => {
+      // Mock readdir to return a partial file
+      vi.mocked(readdir).mockResolvedValue(['testPartial.hbs'] as any);
+      vi.mocked(stat).mockResolvedValue({
+        mtimeMs: Date.now(),
+        isFile: () => true,
+        isDirectory: () => false
+      } as any);
+      vi.mocked(readFile).mockResolvedValue('Partial content: {{data}}');
+
+      const template = '{{> testPartial}}';
+      
+      const compiled = await templateLoader.compileTemplate(template);
+      const result = compiled({ data: 'test data' });
+
+      expect(result).toBe('Partial content: test data');
+    });
+  });
+
+  describe('clearCache', () => {
+    it('should clear the prompt cache', async () => {
+      const prompt = `---
+name: test
+template: Test {{var}}`;
+
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(readFile).mockResolvedValue(prompt);
+      vi.mocked(stat).mockResolvedValue({
+        mtimeMs: Date.now(),
+        mtime: new Date(),
+        isFile: () => true,
+        isDirectory: () => false
+      } as any);
+
+      // Populate cache
+      await templateLoader.loadPrompt('test');
+      expect(readFile).toHaveBeenCalledTimes(1);
+      
+      // Clear cache
+      templateLoader.clearCache();
+
+      // Verify cache is empty by checking if files are read again
+      await templateLoader.loadPrompt('test');
+      expect(readFile).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/mcp-server/src/templates/prompts/create_idea.yaml
+++ b/mcp-server/src/templates/prompts/create_idea.yaml
@@ -1,0 +1,125 @@
+name: create_idea
+description: Capture and organize ideas as GitHub Project draft items through conversation
+arguments: []
+template: |
+  # Capture Project Idea
+  
+  **IMPORTANT:** Follow from Top to Bottom - don't skip anything!
+  
+  **CREATE A TODO LIST** with exactly these 5 items:
+  
+  1. Engage in idea discussion
+  2. Structure the idea content
+  3. Determine idea type and priority
+  4. Create draft item in GitHub Project
+  5. Link related context
+  
+  ## 1 · Engage in idea discussion
+  
+  Ask the user: "What's your idea? Let's explore it together."
+  
+  Have a natural conversation to understand:
+  - The core concept
+  - Why it matters
+  - Potential implementation approaches
+  - Any concerns or unknowns
+  
+  {{#if (lt project.riskLevel 5)}}
+  Ask clarifying questions until the idea is well-formed:
+  - What problem does this solve?
+  - How might users benefit?
+  - What are the technical considerations?
+  - Any dependencies or blockers?
+  {{else}}
+  Quickly capture the essence and key points
+  {{/if}}
+  
+  Continue the conversation until you have enough context to document the idea properly.
+  
+  ## 2 · Structure the idea content
+  
+  Based on the discussion, create a structured summary:
+  
+  **Title**: [Concise, descriptive title]
+  
+  **Description**:
+  - Problem/Opportunity: [What gap or need does this address?]
+  - Proposed Solution: [Core concept and approach]
+  - Benefits: [Expected value and impact]
+  
+  **Technical Notes**:
+  - Implementation considerations
+  - Potential challenges
+  - Dependencies or prerequisites
+  
+  **Open Questions**:
+  - [List any unknowns or areas needing research]
+  
+  ## 3 · Determine idea type and priority
+  
+  Analyze the idea to categorize it:
+  
+  **Type**:
+  - Feature: New functionality
+  - Enhancement: Improvement to existing feature
+  - Research: Investigation needed
+  - Architecture: System design change
+  - Other: [Specify]
+  
+  **Priority Assessment**:
+  - Impact: [High/Medium/Low]
+  - Effort: [High/Medium/Low]
+  - Urgency: [High/Medium/Low]
+  
+  {{#if (lt project.riskLevel 5)}}
+  Confirm categorization with the user
+  {{/if}}
+  
+  ## 4 · Create draft item in GitHub Project
+  
+  {{#if github.github_projects.enabled}}
+  {{> github}}
+  
+  Create a new project item as a draft:
+  
+  ```bash
+  gh project item-add {{github.github_projects.project_id}} \
+    --owner {{github.repository}} \
+    --title "[TITLE]" \
+    --body "[STRUCTURED CONTENT FROM STEP 2]"
+  ```
+  
+  The item will be created at the idea status: `{{github.github_projects.idea_status}}`
+  
+  Note the created item ID for reference.
+  {{else}}
+  **GitHub Projects not configured** - Document the idea locally or create a draft issue instead.
+  
+  Ask the user: "GitHub Projects isn't configured. Would you like to create a draft issue instead?"
+  {{/if}}
+  
+  ## 5 · Link related context
+  
+  Connect the idea to relevant context:
+  
+  - Search for related issues or PRs
+  - Identify relevant code areas
+  - Link to documentation or discussions
+  
+  {{#if github.github_projects.enabled}}
+  Update the project item with links to related content if found.
+  {{/if}}
+  
+  Log the captured idea:
+  ```
+  activity: "Captured project idea"
+  tool_name: "create_idea"
+  tags: ["idea", "planning"]
+  context: "[Brief idea summary]"
+  ```
+  
+  ✅ **Result**: [Describe what was captured - idea title and where it was stored]
+  
+  💡 **Idea Type**: [State the categorized type and priority assessment]
+  
+  💬 **Summary**: [Provide summary of the idea discussion and next steps]

--- a/mcp-server/src/templates/prompts/create_issue.yaml
+++ b/mcp-server/src/templates/prompts/create_issue.yaml
@@ -125,6 +125,22 @@ template: |
   After creating the issue, link it to issue #{{related_issue}} by adding a comment that references the new issue number.
   {{/if}}
   
+  {{#if github.github_projects.enabled}}
+  ### Add Issue to GitHub Project
+  
+  Add the newly created issue to the project at the configured status:
+  ```bash
+  gh project item-add {{github.github_projects.project_id}} --owner {{github.repository}} --url [ISSUE_URL]
+  ```
+  
+  Then update its status to the new issue status:
+  ```bash
+  gh project item-edit --id [ITEM_ID] --field-id [STATUS_FIELD_ID] --project-id {{github.github_projects.project_id}} --single-select-option-id [{{github.github_projects.new_issue_status}}_ID]
+  ```
+  
+  The issue is now tracked in the project at status: `{{github.github_projects.new_issue_status}}`
+  {{/if}}
+  
   ✅ **Result**: [Describe the actual outcome - issue number created and any relevant details]
   
   🔎 **Scope**: [Describe the scope - complexity score, number of affected files, and project areas]

--- a/mcp-server/src/templates/prompts/init_simone.yaml
+++ b/mcp-server/src/templates/prompts/init_simone.yaml
@@ -147,6 +147,42 @@ template: |
   
   Update project.yaml with correct GitHub settings if needed.
   
+  ### GitHub Projects Integration (Optional)
+  
+  Ask the user: "Would you like to integrate GitHub Projects for idea capture and work queue management?"
+  
+  If yes:
+  
+  1. **Find or create project**:
+     - List existing projects: `gh project list --owner [owner]`
+     - If no suitable project exists, get user confirmation to create new one
+     - Create project if needed: `gh project create --owner [owner] --title "[Project Name]"`
+  
+  2. **Discover available statuses**:
+     - Get project field data: `gh api graphql -f query='query{node(id:"[PROJECT_ID]"){...on ProjectV2{fields(first:20){nodes{...on ProjectV2SingleSelectField{name options{name}}}}}}}'`
+     - Extract status field options
+     - Display available statuses to user
+  
+  3. **Configure status mappings**:
+     - Ask user to map statuses for:
+       - idea_status: Where draft ideas are captured (e.g., "Ideas", "Draft")
+       - work_status: Where to pull work items from (e.g., "Ready", "Todo")
+       - new_issue_status: Where newly created issues go (e.g., "Backlog", "New")
+  
+  4. **Update configuration**:
+     ```yaml
+     github:
+       repository: owner/repo
+       tool: cli
+       github_projects:
+         enabled: true
+         project_id: PVT_[ID]
+         idea_status: [selected status]
+         work_status: [selected status]
+         new_issue_status: [selected status]
+         available_statuses: [list of discovered statuses]
+     ```
+  
   ## 7 · Complete initialization
   
   Check if {{PROJECT_PATH}}/CLAUDE.md exists:

--- a/mcp-server/src/templates/prompts/partials/github_project.hbs
+++ b/mcp-server/src/templates/prompts/partials/github_project.hbs
@@ -1,0 +1,34 @@
+{{!-- GitHub Projects operations based on configuration --}}
+{{#if github.github_projects}}
+{{#if github.github_projects.enabled}}
+## GitHub Projects Integration
+
+Project ID: `{{github.github_projects.project_id}}`
+
+Use GitHub CLI for project operations:
+
+### Adding items to project
+```bash
+gh project item-add {{github.github_projects.project_id}} --owner {{github.repository}} --title "TITLE" --body "BODY"
+```
+
+### Updating item status
+```bash
+gh project item-edit --id ITEM_ID --field-id STATUS_FIELD_ID --project-id {{github.github_projects.project_id}} --owner {{github.repository}}
+```
+
+### Querying project items by status
+```bash
+gh project item-list {{github.github_projects.project_id}} --owner {{github.repository}} --format json | jq '.items[] | select(.status == "{{github.github_projects.work_status}}")'
+```
+
+Status mappings:
+- Ideas/drafts: `{{github.github_projects.idea_status}}`
+- Work queue: `{{github.github_projects.work_status}}`
+- New issues: `{{github.github_projects.new_issue_status}}`
+{{#if github.github_projects.available_statuses}}
+
+Available statuses: {{#each github.github_projects.available_statuses}}`{{this}}`{{#unless @last}}, {{/unless}}{{/each}}
+{{/if}}
+{{/if}}
+{{/if}}

--- a/mcp-server/src/templates/prompts/work_issue.yaml
+++ b/mcp-server/src/templates/prompts/work_issue.yaml
@@ -23,12 +23,31 @@ template: |
   {{#if issue}}
   Fetching issue #{{issue}} content
   {{else}}
-  If the issue argument doesn't contain helpful information, ask the user what they want to work on.
+  {{#if github.github_projects.enabled}}
+  ### Check GitHub Projects Work Queue
+  
+  Query items from the work queue status:
+  ```bash
+  gh project item-list {{github.github_projects.project_id}} --owner {{github.repository}} --format json | jq '.items[] | select(.status == "{{github.github_projects.work_status}}")'
+  ```
+  
+  If work items are found:
+  - List them with their titles and descriptions
+  - Ask the user which item they want to work on
+  - Get the associated issue number if the item is linked to an issue
+  
+  If no work items are found or user doesn't select one:
+  {{/if}}
+  Ask the user what they want to work on.
   {{/if}}
   
   {{> github}}
   
+  {{#if issue}}
   Fetch issue #{{issue}} details to understand the requirements.
+  {{else}}
+  Once an issue is selected, fetch its details to understand the requirements.
+  {{/if}}
   
   Read the issue content carefully and identify:
   - Core problem or feature to implement

--- a/mcp-server/src/tools/__tests__/database.test.ts
+++ b/mcp-server/src/tools/__tests__/database.test.ts
@@ -1,0 +1,291 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { DatabaseConnection } from '../database.js';
+import { join } from 'path';
+import { mkdirSync, rmSync, existsSync } from 'fs';
+import { tmpdir } from 'os';
+
+// Mock the logger
+vi.mock('../../utils/logger.js', () => ({
+  logError: vi.fn().mockResolvedValue(undefined),
+  logDebug: vi.fn().mockResolvedValue(undefined),
+}));
+
+describe('DatabaseConnection', () => {
+  let testProjectPath: string;
+  let dbConnection: DatabaseConnection;
+
+  beforeEach(() => {
+    // Create temporary test directory
+    testProjectPath = join(tmpdir(), `db-test-${Date.now()}`);
+    mkdirSync(testProjectPath, { recursive: true });
+  });
+
+  afterEach(() => {
+    // Close connection if exists
+    if (dbConnection) {
+      try {
+        dbConnection.close();
+      } catch (error) {
+        // Ignore close errors
+      }
+    }
+
+    // Clean up test directory
+    try {
+      rmSync(testProjectPath, { recursive: true, force: true });
+    } catch (error) {
+      // Ignore cleanup errors
+    }
+  });
+
+  describe('constructor', () => {
+    it('should create database in .simone directory', () => {
+      dbConnection = new DatabaseConnection(testProjectPath);
+      
+      const dbPath = join(testProjectPath, '.simone', 'simone.db');
+      expect(existsSync(dbPath)).toBe(true);
+    });
+
+    it('should create .simone directory if it does not exist', () => {
+      const simoneDir = join(testProjectPath, '.simone');
+      expect(existsSync(simoneDir)).toBe(false);
+      
+      dbConnection = new DatabaseConnection(testProjectPath);
+      
+      expect(existsSync(simoneDir)).toBe(true);
+    });
+
+    it('should handle existing .simone directory', () => {
+      const simoneDir = join(testProjectPath, '.simone');
+      mkdirSync(simoneDir, { recursive: true });
+      
+      expect(() => {
+        dbConnection = new DatabaseConnection(testProjectPath);
+      }).not.toThrow();
+    });
+
+    it('should set correct database pragmas', () => {
+      dbConnection = new DatabaseConnection(testProjectPath);
+      const db = dbConnection.getDb();
+      
+      // Check foreign keys (returns array with object)
+      const foreignKeys = db.pragma('foreign_keys');
+      expect(foreignKeys[0].foreign_keys).toBe(1);
+      
+      // Check journal mode (returns array with object)
+      const journalMode = db.pragma('journal_mode');
+      expect(journalMode[0].journal_mode).toBe('wal');
+      
+      // Check busy timeout (returns array with object)
+      const busyTimeout = db.pragma('busy_timeout');
+      expect(busyTimeout[0].timeout).toBe(10000);
+    });
+
+    it('should initialize schema on first run', () => {
+      dbConnection = new DatabaseConnection(testProjectPath);
+      const db = dbConnection.getDb();
+      
+      // Check tables exist
+      const tables = db.prepare(
+        "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name"
+      ).all() as Array<{ name: string }>;
+      
+      const tableNames = tables.map(t => t.name);
+      expect(tableNames).toContain('activity_log');
+      expect(tableNames).toContain('activity_tags');
+      expect(tableNames).toContain('activity_log_tags');
+      expect(tableNames).toContain('activity_files');
+    });
+
+    it('should not reinitialize schema on subsequent runs', () => {
+      // First connection
+      dbConnection = new DatabaseConnection(testProjectPath);
+      const db1 = dbConnection.getDb();
+      
+      // Insert test data
+      db1.prepare('INSERT INTO activity_tags (name) VALUES (?)').run('test-tag');
+      
+      dbConnection.close();
+      
+      // Second connection
+      dbConnection = new DatabaseConnection(testProjectPath);
+      const db2 = dbConnection.getDb();
+      
+      // Check test data still exists
+      const tag = db2.prepare('SELECT * FROM activity_tags WHERE name = ?').get('test-tag') as any;
+      expect(tag).toBeDefined();
+      expect(tag.name).toBe('test-tag');
+    });
+
+    it('should handle permission errors', () => {
+      // Create read-only directory
+      const readOnlyDir = join(testProjectPath, '.simone');
+      mkdirSync(readOnlyDir, { recursive: true, mode: 0o444 });
+      
+      // This might not work on all systems, so we'll just check it doesn't crash
+      try {
+        dbConnection = new DatabaseConnection(testProjectPath);
+        // If it succeeds, that's fine (some systems ignore mode)
+        expect(dbConnection).toBeDefined();
+      } catch (error) {
+        // If it fails, check for appropriate error
+        expect(error).toBeInstanceOf(Error);
+        expect((error as Error).message).toContain('Database initialization failed');
+      }
+    });
+  });
+
+  describe('getDb', () => {
+    it('should return Database instance', () => {
+      dbConnection = new DatabaseConnection(testProjectPath);
+      const db = dbConnection.getDb();
+      
+      expect(db).toBeDefined();
+      expect(db.constructor.name).toBe('Database');
+    });
+
+    it('should return same instance on multiple calls', () => {
+      dbConnection = new DatabaseConnection(testProjectPath);
+      const db1 = dbConnection.getDb();
+      const db2 = dbConnection.getDb();
+      
+      expect(db1).toBe(db2);
+    });
+  });
+
+  describe('close', () => {
+    it('should close database connection', () => {
+      dbConnection = new DatabaseConnection(testProjectPath);
+      const db = dbConnection.getDb();
+      
+      expect(db.open).toBe(true);
+      
+      dbConnection.close();
+      
+      expect(db.open).toBe(false);
+    });
+
+    it('should handle multiple close calls', () => {
+      dbConnection = new DatabaseConnection(testProjectPath);
+      
+      expect(() => {
+        dbConnection.close();
+        dbConnection.close();
+      }).not.toThrow();
+    });
+  });
+
+  describe('schema validation', () => {
+    beforeEach(() => {
+      dbConnection = new DatabaseConnection(testProjectPath);
+    });
+
+    it('should create activity_log table with correct schema', () => {
+      const db = dbConnection.getDb();
+      const columns = db.pragma('table_info(activity_log)') as Array<{
+        name: string;
+        type: string;
+        notnull: number;
+        dflt_value: any;
+        pk: number;
+      }>;
+      
+      const columnMap = new Map(columns.map(c => [c.name, c]));
+      
+      expect(columnMap.has('id')).toBe(true);
+      expect(columnMap.get('id')?.pk).toBe(1);
+      
+      expect(columnMap.has('timestamp')).toBe(true);
+      expect(columnMap.has('activity')).toBe(true);
+      expect(columnMap.get('activity')?.notnull).toBe(1);
+      
+      expect(columnMap.has('activity_type')).toBe(true);
+      expect(columnMap.get('activity_type')?.notnull).toBe(1);
+      
+      expect(columnMap.has('tool_name')).toBe(true);
+      expect(columnMap.get('tool_name')?.notnull).toBe(1);
+      
+      expect(columnMap.has('success')).toBe(true);
+      expect(columnMap.has('error')).toBe(true);
+      expect(columnMap.has('context')).toBe(true);
+      expect(columnMap.has('issue_number')).toBe(true);
+      expect(columnMap.has('link')).toBe(true);
+    });
+
+    it('should create proper indexes', () => {
+      const db = dbConnection.getDb();
+      const indexes = db.prepare(
+        "SELECT name FROM sqlite_master WHERE type='index' AND name LIKE 'idx_%'"
+      ).all() as Array<{ name: string }>;
+      
+      const indexNames = indexes.map(i => i.name);
+      
+      expect(indexNames).toContain('idx_activity_log_timestamp');
+      expect(indexNames).toContain('idx_activity_log_tool_name');
+      expect(indexNames).toContain('idx_activity_log_activity_type');
+      expect(indexNames).toContain('idx_activity_log_success');
+      expect(indexNames).toContain('idx_activity_tags_name');
+    });
+
+    it('should enforce foreign key constraints', () => {
+      const db = dbConnection.getDb();
+      
+      // Try to insert invalid activity_log_tags entry
+      expect(() => {
+        db.prepare(
+          'INSERT INTO activity_log_tags (activity_id, tag_id) VALUES (?, ?)'
+        ).run(999, 999);
+      }).toThrow();
+    });
+
+    it('should handle activity logging workflow', () => {
+      const db = dbConnection.getDb();
+      
+      // Insert activity
+      const activityResult = db.prepare(`
+        INSERT INTO activity_log (activity, activity_type, tool_name, success)
+        VALUES (?, ?, ?, ?)
+      `).run('Test activity', 'test', 'test-tool', 1);
+      
+      const activityId = activityResult.lastInsertRowid;
+      
+      // Insert tag
+      const tagResult = db.prepare('INSERT INTO activity_tags (name) VALUES (?)').run('test-tag');
+      const tagId = tagResult.lastInsertRowid;
+      
+      // Link activity to tag
+      db.prepare('INSERT INTO activity_log_tags (activity_id, tag_id) VALUES (?, ?)').run(activityId, tagId);
+      
+      // Insert affected file
+      db.prepare(`
+        INSERT INTO activity_files (activity_id, file_path, operation)
+        VALUES (?, ?, ?)
+      `).run(activityId, '/test/file.ts', 'create');
+      
+      // Verify data integrity
+      const activity = db.prepare('SELECT * FROM activity_log WHERE id = ?').get(activityId) as any;
+      expect(activity.activity).toBe('Test activity');
+      
+      const tags = db.prepare(`
+        SELECT t.name FROM activity_tags t
+        JOIN activity_log_tags alt ON t.id = alt.tag_id
+        WHERE alt.activity_id = ?
+      `).all(activityId) as Array<{ name: string }>;
+      expect(tags[0].name).toBe('test-tag');
+      
+      const files = db.prepare('SELECT * FROM activity_files WHERE activity_id = ?').all(activityId) as any[];
+      expect(files[0].file_path).toBe('/test/file.ts');
+    });
+  });
+
+  describe('error handling', () => {
+    it('should handle invalid project path', () => {
+      // Try to create database in a path that can't exist
+      const invalidPath = '/\0invalid\0path';
+      
+      expect(() => {
+        new DatabaseConnection(invalidPath);
+      }).toThrow('Database initialization failed');
+    });
+  });
+});

--- a/mcp-server/src/tools/__tests__/index.test.ts
+++ b/mcp-server/src/tools/__tests__/index.test.ts
@@ -1,0 +1,274 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { getTools, getToolSchemas, handleToolCall } from '../index.js';
+import type { ToolContext, ToolDefinition } from '../index.js';
+import { createTestDatabase } from '../../__tests__/utils/test-database.js';
+import { ActivityLogger } from '../activity-logger/index.js';
+import Database from 'better-sqlite3';
+
+describe('Tool Registry', () => {
+  let context: ToolContext;
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = createTestDatabase();
+    context = {
+      projectPath: '/test/project',
+      activityLogger: new ActivityLogger('/test/project', db),
+      database: db,
+    };
+  });
+
+  afterEach(() => {
+    if (db && db.open) {
+      db.close();
+    }
+  });
+
+  describe('getTools', () => {
+    it('should return a Map of tool definitions', () => {
+      const tools = getTools(context);
+      
+      expect(tools).toBeInstanceOf(Map);
+      expect(tools.size).toBeGreaterThan(0);
+    });
+
+    it('should register log_activity tool', () => {
+      const tools = getTools(context);
+      
+      expect(tools.has('log_activity')).toBe(true);
+      
+      const logActivityTool = tools.get('log_activity');
+      expect(logActivityTool).toBeDefined();
+      expect(logActivityTool?.tool.name).toBe('log_activity');
+      expect(logActivityTool?.handler).toBeInstanceOf(Function);
+    });
+
+    it('should return new Map instance each time', () => {
+      const tools1 = getTools(context);
+      const tools2 = getTools(context);
+      
+      expect(tools1).not.toBe(tools2);
+      expect(tools1.size).toBe(tools2.size);
+    });
+
+    it('should pass context to tool handlers', async () => {
+      const tools = getTools(context);
+      const logActivityTool = tools.get('log_activity');
+      
+      const args = {
+        activity: 'Test activity',
+        tool_name: 'test',
+      };
+      
+      const result = await logActivityTool!.handler(args, context);
+      
+      expect(result.content[0].text).toContain('Activity logged successfully');
+    });
+  });
+
+  describe('getToolSchemas', () => {
+    it('should return array of tool schemas', () => {
+      const tools = getTools(context);
+      const schemas = getToolSchemas(tools);
+      
+      expect(Array.isArray(schemas)).toBe(true);
+      expect(schemas.length).toBe(tools.size);
+    });
+
+    it('should return tool objects without handlers', () => {
+      const tools = getTools(context);
+      const schemas = getToolSchemas(tools);
+      
+      schemas.forEach(schema => {
+        expect(schema).toHaveProperty('name');
+        expect(schema).toHaveProperty('description');
+        expect(schema).toHaveProperty('inputSchema');
+        expect(schema).not.toHaveProperty('handler');
+      });
+    });
+
+    it('should include log_activity tool schema', () => {
+      const tools = getTools(context);
+      const schemas = getToolSchemas(tools);
+      
+      const logActivitySchema = schemas.find(s => s.name === 'log_activity');
+      expect(logActivitySchema).toBeDefined();
+      expect(logActivitySchema?.description).toContain('Log your AI-assisted development activities');
+    });
+  });
+
+  describe('handleToolCall', () => {
+    let tools: Map<string, ToolDefinition>;
+
+    beforeEach(() => {
+      tools = getTools(context);
+    });
+
+    it('should handle valid tool call', async () => {
+      const result = await handleToolCall(
+        'log_activity',
+        {
+          activity: 'Test activity',
+          tool_name: 'test',
+        },
+        tools,
+        context
+      );
+
+      expect(result.content).toBeDefined();
+      expect(result.content[0].text).toContain('Activity logged successfully');
+      expect(result.isError).toBeUndefined();
+    });
+
+    it('should handle unknown tool', async () => {
+      const result = await handleToolCall(
+        'unknown_tool',
+        {},
+        tools,
+        context
+      );
+
+      expect(result.content[0].text).toBe('Unknown tool: unknown_tool');
+      expect(result.isError).toBe(true);
+    });
+
+    it('should pass arguments to tool handler', async () => {
+      const testArgs = {
+        activity: 'Complex activity',
+        tool_name: 'complex-tool',
+        tags: ['tag1', 'tag2'],
+        context: 'Additional context',
+      };
+
+      const result = await handleToolCall(
+        'log_activity',
+        testArgs,
+        tools,
+        context
+      );
+
+      expect(result.content[0].text).toContain('Activity logged successfully');
+      
+      // Verify in database
+      const activity = db.prepare('SELECT * FROM activity_log WHERE activity = ?').get('Complex activity') as any;
+      expect(activity).toBeDefined();
+      expect(activity.tool_name).toBe('complex-tool');
+      expect(activity.context).toBe('Additional context');
+    });
+
+    it('should handle tool errors gracefully', async () => {
+      // Close database to cause error
+      db.close();
+
+      const result = await handleToolCall(
+        'log_activity',
+        {
+          activity: 'Test',
+          tool_name: 'test',
+        },
+        tools,
+        context
+      );
+
+      expect(result.content[0].text).toContain('CRITICAL ERROR');
+      expect(result.isError).toBe(true);
+    });
+
+    it('should handle empty arguments', async () => {
+      const result = await handleToolCall(
+        'log_activity',
+        {},
+        tools,
+        context
+      );
+
+      // Should fail due to missing required arguments
+      expect(result.isError).toBe(true);
+    });
+
+    it('should handle custom tool registration', async () => {
+      // Create custom tool
+      const customTool: ToolDefinition = {
+        tool: {
+          name: 'custom_tool',
+          description: 'A custom test tool',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              message: { type: 'string' },
+            },
+            required: ['message'],
+          },
+        },
+        handler: async (args) => ({
+          content: [
+            {
+              type: 'text',
+              text: `Custom tool received: ${args.message}`,
+            },
+          ],
+        }),
+      };
+
+      // Add custom tool to registry
+      tools.set('custom_tool', customTool);
+
+      // Call custom tool
+      const result = await handleToolCall(
+        'custom_tool',
+        { message: 'Hello from test' },
+        tools,
+        context
+      );
+
+      expect(result.content[0].text).toBe('Custom tool received: Hello from test');
+      expect(result.isError).toBeUndefined();
+    });
+  });
+
+  describe('Tool Context', () => {
+    it('should provide access to project path', async () => {
+      const tools = getTools(context);
+      const customContext = {
+        ...context,
+        projectPath: '/custom/path',
+      };
+
+      // Create custom tool that uses project path
+      const pathTool: ToolDefinition = {
+        tool: {
+          name: 'path_tool',
+          description: 'Test tool that uses project path',
+          inputSchema: { type: 'object', properties: {} },
+        },
+        handler: async (_, ctx) => ({
+          content: [
+            {
+              type: 'text',
+              text: `Project path: ${ctx.projectPath}`,
+            },
+          ],
+        }),
+      };
+
+      tools.set('path_tool', pathTool);
+
+      const result = await handleToolCall(
+        'path_tool',
+        {},
+        tools,
+        customContext
+      );
+
+      expect(result.content[0].text).toBe('Project path: /custom/path');
+    });
+
+    it('should provide access to shared services', () => {
+      const tools = getTools(context);
+      
+      expect(context.activityLogger).toBeInstanceOf(ActivityLogger);
+      expect(context.database).toBeDefined();
+      expect(context.projectPath).toBe('/test/project');
+    });
+  });
+});

--- a/mcp-server/src/tools/activity-logger/__tests__/activity-types.test.ts
+++ b/mcp-server/src/tools/activity-logger/__tests__/activity-types.test.ts
@@ -1,0 +1,231 @@
+import { describe, it, expect } from 'vitest';
+import { detectActivityType } from '../activity-types.js';
+
+describe('detectActivityType', () => {
+  describe('should detect create activities', () => {
+    it.each([
+      'Created new test file',
+      'Add configuration file',
+      'Generated API documentation',
+      'Initialize project structure',
+      'Create GitHub issue for bug fix'
+    ])('detects create in: "%s"', (activity) => {
+      expect(detectActivityType(activity)).toBe('create');
+    });
+  });
+
+  describe('should detect update activities', () => {
+    it.each([
+      'Updated configuration settings',
+      'Modified test suite',
+      'Changed API endpoint',
+      'Edit documentation'
+    ])('detects update in: "%s"', (activity) => {
+      expect(detectActivityType(activity)).toBe('update');
+    });
+  });
+
+  describe('should detect fix activities', () => {
+    it.each([
+      'Fixed authentication bug',
+      'Repaired broken tests',
+      'Resolved merge conflict',
+      'Patched security vulnerability'
+    ])('detects fix in: "%s"', (activity) => {
+      expect(detectActivityType(activity)).toBe('fix');
+    });
+  });
+
+  describe('should detect review activities', () => {
+    it.each([
+      'Reviewed pull request',
+      'Check code quality',
+      'Examined test coverage',
+      'Inspect deployment logs'
+    ])('detects review in: "%s"', (activity) => {
+      expect(detectActivityType(activity)).toBe('review');
+    });
+  });
+
+  describe('should detect research activities', () => {
+    it.each([
+      'Researched authentication libraries',
+      'Investigated performance issues',
+      'Explored new frameworks',
+      'Searched for bug solution'
+    ])('detects research in: "%s"', (activity) => {
+      expect(detectActivityType(activity)).toBe('research');
+    });
+  });
+
+  describe('should detect document activities', () => {
+    it.each([
+      'Documented API endpoints',
+      'Write setup guide',
+      'Described architecture decisions',
+      'Explained configuration options'
+    ])('detects document in: "%s"', (activity) => {
+      expect(detectActivityType(activity)).toBe('document');
+    });
+  });
+
+  describe('should detect test activities', () => {
+    it.each([
+      'Tested authentication flow',
+      'Verify API responses',
+      'Validated form inputs'
+    ])('detects test in: "%s"', (activity) => {
+      expect(detectActivityType(activity)).toBe('test');
+    });
+
+    it('should detect review when check is the primary verb', () => {
+      // 'check' keyword appears first in the review category
+      expect(detectActivityType('Check deployment status')).toBe('review');
+    });
+  });
+
+  describe('should detect deploy activities', () => {
+    it.each([
+      'Deployed to production',
+      'Released version 2.0',
+      'Published npm package'
+    ])('detects deploy in: "%s"', (activity) => {
+      expect(detectActivityType(activity)).toBe('deploy');
+    });
+
+    it('should detect create when launched is used with new', () => {
+      // 'new' keyword triggers create detection
+      expect(detectActivityType('Launched new feature')).toBe('create');
+    });
+  });
+
+  describe('should detect configure activities', () => {
+    it.each([
+      'Configured CI/CD pipeline',
+      'Setup development environment',
+      'Installed dependencies',
+      'Config database connection'
+    ])('detects configure in: "%s"', (activity) => {
+      expect(detectActivityType(activity)).toBe('configure');
+    });
+  });
+
+  describe('should detect refactor activities', () => {
+    it.each([
+      'Refactored authentication module',
+      'Reorganized file structure',
+      'Restructured database schema',
+      'Cleaned up old code'
+    ])('detects refactor in: "%s"', (activity) => {
+      expect(detectActivityType(activity)).toBe('refactor');
+    });
+  });
+
+  describe('should detect delete activities', () => {
+    it.each([
+      'Removed deprecated API',
+      'Drop obsolete tables'
+    ])('detects delete in: "%s"', (activity) => {
+      expect(detectActivityType(activity)).toBe('delete');
+    });
+
+    it('should detect test when deleted is used with test files', () => {
+      // 'test' keyword appears before 'delete' in the keyword order
+      expect(detectActivityType('Deleted old test files')).toBe('test');
+    });
+
+    it('should detect clean as refactor when it is the main verb', () => {
+      expect(detectActivityType('Cleaned unused dependencies')).toBe('refactor');
+    });
+  });
+
+  describe('should detect analyze activities', () => {
+    it.each([
+      'Analyzed performance metrics',
+      'Assessed code quality',
+      'Measured API response times'
+    ])('detects analyze in: "%s"', (activity) => {
+      expect(detectActivityType(activity)).toBe('analyze');
+    });
+
+    it('should detect test when evaluate is used with test', () => {
+      expect(detectActivityType('Evaluated test coverage')).toBe('test');
+    });
+  });
+
+  describe('should detect plan activities', () => {
+    it.each([
+      'Planned sprint tasks',
+      'Architected microservices',
+      'Outlined project roadmap'
+    ])('detects plan in: "%s"', (activity) => {
+      expect(detectActivityType(activity)).toBe('plan');
+    });
+
+    it('should detect create when design is used with new', () => {
+      expect(detectActivityType('Designed new architecture')).toBe('create');
+    });
+  });
+
+  describe('should detect debug activities', () => {
+    it.each([
+      'Debugged memory leak',
+      'Diagnosed performance problem',
+      'Traced error source'
+    ])('detects debug in: "%s"', (activity) => {
+      expect(detectActivityType(activity)).toBe('debug');
+    });
+
+    it('should detect deploy when troubleshoot is used with deployment', () => {
+      expect(detectActivityType('Troubleshoot deployment issue')).toBe('deploy');
+    });
+  });
+
+  describe('should handle edge cases', () => {
+    it('should be case insensitive', () => {
+      expect(detectActivityType('CREATE new file')).toBe('create');
+      expect(detectActivityType('UPDATED config')).toBe('update');
+      expect(detectActivityType('FiXeD bug')).toBe('fix');
+    });
+
+    it('should detect keyword anywhere in the activity', () => {
+      expect(detectActivityType('Worked on creating new feature')).toBe('create');
+      expect(detectActivityType('Spent time to fix the issue')).toBe('fix');
+    });
+
+    it('should prioritize first matching type', () => {
+      // Contains both 'create' and 'test' keywords, but 'create' comes first in the order
+      expect(detectActivityType('Created new test file')).toBe('create');
+    });
+  });
+
+  describe('should fallback behavior', () => {
+    it('should extract first verb for unmatched activities', () => {
+      expect(detectActivityType('Migrated database')).toBe('migrated');
+      expect(detectActivityType('Optimized performance')).toBe('optimized');
+    });
+
+    it('should detect create when implemented is used with new', () => {
+      expect(detectActivityType('Implemented new feature')).toBe('create');
+    });
+
+    it('should return "other" for very short first words', () => {
+      expect(detectActivityType('Is working')).toBe('other');
+    });
+
+    it('should detect keywords even in short sentences', () => {
+      expect(detectActivityType('A new feature')).toBe('create'); // 'new' keyword
+    });
+
+    it('should handle "To do list" as other', () => {
+      // 'To' is too short, no matching keywords
+      expect(detectActivityType('To do list')).toBe('other');
+    });
+
+    it('should return first word or "other" for no match', () => {
+      expect(detectActivityType('')).toBe('other');
+      expect(detectActivityType(' ')).toBe('other');
+      expect(detectActivityType('123')).toBe('123'); // First word, even if numeric
+    });
+  });
+});

--- a/mcp-server/src/tools/activity-logger/__tests__/index.test.ts
+++ b/mcp-server/src/tools/activity-logger/__tests__/index.test.ts
@@ -1,0 +1,371 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { ActivityLogger } from '../index.js';
+import { createTestDatabase } from '../../../__tests__/utils/test-database.js';
+import type { LogActivityParams } from '../types.js';
+import Database from 'better-sqlite3';
+
+// Mock the logger
+vi.mock('../../../utils/logger.js', () => ({
+  logError: vi.fn()
+}));
+
+describe('ActivityLogger', () => {
+  let db: Database.Database;
+  let activityLogger: ActivityLogger;
+  const projectPath = '/test/project';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    db = createTestDatabase();
+    activityLogger = new ActivityLogger(projectPath, db);
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  describe('logActivity', () => {
+    it('should log a basic activity successfully', () => {
+      const params: LogActivityParams = {
+        activity: 'Created test file',
+        tool_name: 'test-tool',
+      };
+
+      const result = activityLogger.logActivity(params);
+
+      expect(result.success).toBe(true);
+      expect(result.activityId).toBeDefined();
+      expect(typeof result.activityId).toBe('number');
+
+      // Verify data was inserted
+      const row = db.prepare('SELECT * FROM activity_log WHERE id = ?').get(result.activityId) as any;
+      expect(row.activity).toBe('Created test file');
+      expect(row.activity_type).toBe('create');
+      expect(row.tool_name).toBe('test-tool');
+      expect(row.success).toBe(1);
+      expect(row.error).toBeNull();
+    });
+
+    it('should log activity with all optional parameters', () => {
+      const params: LogActivityParams = {
+        activity: 'Fixed authentication bug',
+        tool_name: 'bug-fixer',
+        success: false,
+        error: 'Failed to apply patch',
+        tags: ['bug-fix', 'authentication', 'critical'],
+        context: 'Attempted to fix login issue',
+        files_affected: ['src/auth.ts', '/test/project/src/login.ts'],
+        issue_number: 123,
+        link: 'https://github.com/user/repo/issues/123'
+      };
+
+      const result = activityLogger.logActivity(params);
+
+      expect(result.success).toBe(true);
+      expect(result.activityId).toBeDefined();
+
+      // Verify main activity
+      const activity = db.prepare('SELECT * FROM activity_log WHERE id = ?').get(result.activityId) as any;
+      expect(activity.activity).toBe('Fixed authentication bug');
+      expect(activity.activity_type).toBe('fix');
+      expect(activity.tool_name).toBe('bug-fixer');
+      expect(activity.success).toBe(0);
+      expect(activity.error).toBe('Failed to apply patch');
+      expect(activity.context).toBe('Attempted to fix login issue');
+      expect(activity.issue_number).toBe(123);
+      expect(activity.link).toBe('https://github.com/user/repo/issues/123');
+
+      // Verify tags
+      const tags = db.prepare(`
+        SELECT t.name 
+        FROM activity_tags t
+        JOIN activity_log_tags alt ON t.id = alt.tag_id
+        WHERE alt.activity_id = ?
+        ORDER BY t.name
+      `).all(result.activityId) as Array<{ name: string }>;
+      expect(tags.map(t => t.name)).toEqual(['authentication', 'bug-fix', 'critical']);
+
+      // Verify files
+      const files = db.prepare(`
+        SELECT file_path, operation 
+        FROM activity_files 
+        WHERE activity_id = ?
+        ORDER BY file_path
+      `).all(result.activityId) as Array<{ file_path: string; operation: string }>;
+      expect(files).toHaveLength(2);
+      expect(files[0]).toEqual({ file_path: 'src/auth.ts', operation: 'modified' });
+      expect(files[1]).toEqual({ file_path: 'src/login.ts', operation: 'modified' });
+    });
+
+    it('should handle success parameter correctly', () => {
+      // Test explicit true
+      const result1 = activityLogger.logActivity({
+        activity: 'Test 1',
+        tool_name: 'test',
+        success: true
+      });
+      expect(result1.success).toBe(true);
+      const row1 = db.prepare('SELECT success FROM activity_log WHERE id = ?').get(result1.activityId) as any;
+      expect(row1.success).toBe(1);
+
+      // Test explicit false
+      const result2 = activityLogger.logActivity({
+        activity: 'Test 2',
+        tool_name: 'test',
+        success: false
+      });
+      expect(result2.success).toBe(true);
+      const row2 = db.prepare('SELECT success FROM activity_log WHERE id = ?').get(result2.activityId) as any;
+      expect(row2.success).toBe(0);
+
+      // Test undefined (defaults to true)
+      const result3 = activityLogger.logActivity({
+        activity: 'Test 3',
+        tool_name: 'test'
+      });
+      expect(result3.success).toBe(true);
+      const row3 = db.prepare('SELECT success FROM activity_log WHERE id = ?').get(result3.activityId) as any;
+      expect(row3.success).toBe(1);
+    });
+
+    it('should limit tags to 3', () => {
+      const params: LogActivityParams = {
+        activity: 'Test activity',
+        tool_name: 'test',
+        tags: ['tag1', 'tag2', 'tag3', 'tag4', 'tag5']
+      };
+
+      const result = activityLogger.logActivity(params);
+      expect(result.success).toBe(true);
+
+      const tags = db.prepare(`
+        SELECT COUNT(*) as count 
+        FROM activity_log_tags 
+        WHERE activity_id = ?
+      `).get(result.activityId) as { count: number };
+      expect(tags.count).toBe(3);
+    });
+
+    it('should normalize tag case to lowercase', () => {
+      const params: LogActivityParams = {
+        activity: 'Test activity',
+        tool_name: 'test',
+        tags: ['BUG-FIX', 'Authentication', 'CRITICAL']
+      };
+
+      const result = activityLogger.logActivity(params);
+      expect(result.success).toBe(true);
+
+      const tags = db.prepare(`
+        SELECT t.name 
+        FROM activity_tags t
+        JOIN activity_log_tags alt ON t.id = alt.tag_id
+        WHERE alt.activity_id = ?
+      `).all(result.activityId) as Array<{ name: string }>;
+      expect(tags.map(t => t.name).sort()).toEqual(['authentication', 'bug-fix', 'critical']);
+    });
+
+    it('should handle duplicate tags', () => {
+      // First activity with tags
+      activityLogger.logActivity({
+        activity: 'First activity',
+        tool_name: 'test',
+        tags: ['bug-fix', 'testing']
+      });
+
+      // Second activity with overlapping tags
+      const result = activityLogger.logActivity({
+        activity: 'Second activity',
+        tool_name: 'test',
+        tags: ['bug-fix', 'testing', 'new-tag']
+      });
+
+      expect(result.success).toBe(true);
+      
+      // Verify tags table doesn't have duplicates
+      const allTags = db.prepare('SELECT name FROM activity_tags ORDER BY name').all() as Array<{ name: string }>;
+      const uniqueTags = [...new Set(allTags.map(t => t.name))];
+      expect(allTags.length).toBe(uniqueTags.length);
+    });
+
+    it('should normalize file paths', () => {
+      const params: LogActivityParams = {
+        activity: 'Modified files',
+        tool_name: 'test',
+        files_affected: [
+          '/test/project/src/absolute.ts',
+          './src/relative.ts',
+          'src/already-relative.ts',
+          '  src/with-spaces.ts  '
+        ]
+      };
+
+      const result = activityLogger.logActivity(params);
+      expect(result.success).toBe(true);
+
+      const files = db.prepare(`
+        SELECT file_path 
+        FROM activity_files 
+        WHERE activity_id = ?
+        ORDER BY file_path
+      `).all(result.activityId) as Array<{ file_path: string }>;
+      
+      expect(files.map(f => f.file_path)).toEqual([
+        'src/absolute.ts',
+        'src/already-relative.ts',
+        'src/relative.ts',
+        'src/with-spaces.ts'
+      ]);
+    });
+
+    it('should handle database errors gracefully', () => {
+      // Close the database to cause an error
+      db.close();
+
+      const result = activityLogger.logActivity({
+        activity: 'Test activity',
+        tool_name: 'test'
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('database connection is not open');
+      expect(result.activityId).toBeUndefined();
+    });
+
+    it('should handle constraint violations', () => {
+      // Mock prepare to throw a constraint error
+      const originalPrepare = db.prepare.bind(db);
+      db.prepare = vi.fn().mockImplementation((sql: string) => {
+        if (sql.includes('INSERT INTO activity_log')) {
+          return {
+            run: () => { throw new Error('UNIQUE constraint failed'); }
+          };
+        }
+        return originalPrepare(sql);
+      });
+
+      const result = activityLogger.logActivity({
+        activity: 'Test activity',
+        tool_name: 'test'
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('UNIQUE constraint failed');
+    });
+
+    it('should rollback transaction on error', () => {
+      // Use a fresh logger instance to ensure clean state
+      const freshLogger = new ActivityLogger(projectPath, db);
+      
+      // Count activities before
+      const countBefore = (db.prepare('SELECT COUNT(*) as count FROM activity_log').get() as { count: number }).count;
+
+      // Mock the database transaction to throw an error
+      const originalTransaction = db.transaction.bind(db);
+      db.transaction = vi.fn().mockImplementation((fn: Function) => {
+        // Create a wrapper that will throw during execution
+        return () => {
+          // Start the transaction
+          const begin = db.prepare('BEGIN');
+          begin.run();
+          
+          try {
+            // Try to run some of the function
+            throw new Error('Tag insertion failed');
+          } catch (e) {
+            // Rollback
+            const rollback = db.prepare('ROLLBACK');
+            rollback.run();
+            throw e;
+          }
+        };
+      });
+
+      const result = freshLogger.logActivity({
+        activity: 'Test activity',
+        tool_name: 'test',
+        tags: ['tag1', 'tag2']
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Tag insertion failed');
+
+      // Restore original transaction
+      db.transaction = originalTransaction;
+
+      // Verify rollback - count should be unchanged
+      const countAfter = (db.prepare('SELECT COUNT(*) as count FROM activity_log').get() as { count: number }).count;
+      expect(countAfter).toBe(countBefore);
+    });
+
+    it('should handle null and undefined values correctly', () => {
+      const params: LogActivityParams = {
+        activity: 'Test activity',
+        tool_name: 'test',
+        error: undefined,
+        context: null as any,
+        issue_number: undefined,
+        link: null as any
+      };
+
+      const result = activityLogger.logActivity(params);
+      expect(result.success).toBe(true);
+
+      const row = db.prepare('SELECT * FROM activity_log WHERE id = ?').get(result.activityId) as any;
+      expect(row.error).toBeNull();
+      expect(row.context).toBeNull();
+      expect(row.issue_number).toBeNull();
+      expect(row.link).toBeNull();
+    });
+
+    it('should handle empty arrays', () => {
+      const params: LogActivityParams = {
+        activity: 'Test activity',
+        tool_name: 'test',
+        tags: [],
+        files_affected: []
+      };
+
+      const result = activityLogger.logActivity(params);
+      expect(result.success).toBe(true);
+
+      // Verify no tags were inserted
+      const tagCount = (db.prepare(`
+        SELECT COUNT(*) as count 
+        FROM activity_log_tags 
+        WHERE activity_id = ?
+      `).get(result.activityId) as { count: number }).count;
+      expect(tagCount).toBe(0);
+
+      // Verify no files were inserted
+      const fileCount = (db.prepare(`
+        SELECT COUNT(*) as count 
+        FROM activity_files 
+        WHERE activity_id = ?
+      `).get(result.activityId) as { count: number }).count;
+      expect(fileCount).toBe(0);
+    });
+
+    it('should detect correct activity types', () => {
+      const testCases = [
+        { activity: 'Created new feature', expectedType: 'create' },
+        { activity: 'Updated documentation', expectedType: 'update' },
+        { activity: 'Fixed critical bug', expectedType: 'fix' },
+        { activity: 'Reviewed pull request', expectedType: 'review' },
+        { activity: 'Researched solutions', expectedType: 'research' }
+      ];
+
+      testCases.forEach(({ activity, expectedType }) => {
+        const result = activityLogger.logActivity({
+          activity,
+          tool_name: 'test'
+        });
+
+        expect(result.success).toBe(true);
+        
+        const row = db.prepare('SELECT activity_type FROM activity_log WHERE id = ?').get(result.activityId) as any;
+        expect(row.activity_type).toBe(expectedType);
+      });
+    });
+  });
+});

--- a/mcp-server/src/tools/activity-logger/__tests__/path-normalizer.test.ts
+++ b/mcp-server/src/tools/activity-logger/__tests__/path-normalizer.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeFilePath } from '../path-normalizer.js';
+import { sep } from 'path';
+
+describe('normalizeFilePath', () => {
+  const projectRoot = '/Users/test/project';
+
+  describe('absolute paths', () => {
+    it('should convert absolute paths within project to relative', () => {
+      const result = normalizeFilePath('/Users/test/project/src/index.ts', projectRoot);
+      expect(result).toBe('src/index.ts');
+    });
+
+    it('should convert deeply nested absolute paths to relative', () => {
+      const result = normalizeFilePath('/Users/test/project/src/components/ui/Button.tsx', projectRoot);
+      expect(result).toBe('src/components/ui/Button.tsx');
+    });
+
+    it('should handle absolute paths outside project', () => {
+      const result = normalizeFilePath('/Users/other/project/file.ts', projectRoot);
+      expect(result).toBe(`..${sep}..${sep}other${sep}project${sep}file.ts`);
+    });
+
+    it('should handle absolute path at project root', () => {
+      const result = normalizeFilePath('/Users/test/project/README.md', projectRoot);
+      expect(result).toBe('README.md');
+    });
+
+    it('should handle absolute path identical to project root', () => {
+      const result = normalizeFilePath(projectRoot, projectRoot);
+      // Node's relative() returns empty string when paths are identical
+      expect(result).toBe('');
+    });
+  });
+
+  describe('relative paths with ./ or ../', () => {
+    it('should normalize paths starting with ./', () => {
+      const result = normalizeFilePath('./src/index.ts', projectRoot);
+      expect(result).toBe('src/index.ts');
+    });
+
+    it('should normalize paths starting with ../', () => {
+      const result = normalizeFilePath('../other-project/file.ts', projectRoot);
+      expect(result).toBe(`..${sep}other-project${sep}file.ts`);
+    });
+
+    it('should handle multiple ../ segments', () => {
+      const result = normalizeFilePath('../../outside/file.ts', projectRoot);
+      expect(result).toBe(`..${sep}..${sep}outside${sep}file.ts`);
+    });
+
+    it('should handle complex relative paths', () => {
+      const result = normalizeFilePath('./src/../lib/utils.ts', projectRoot);
+      expect(result).toBe('lib/utils.ts');
+    });
+  });
+
+  describe('already relative paths', () => {
+    it('should keep simple relative paths unchanged', () => {
+      const result = normalizeFilePath('src/index.ts', projectRoot);
+      expect(result).toBe('src/index.ts');
+    });
+
+    it('should keep nested relative paths unchanged', () => {
+      const result = normalizeFilePath('src/components/ui/Button.tsx', projectRoot);
+      expect(result).toBe('src/components/ui/Button.tsx');
+    });
+
+    it('should keep single file names unchanged', () => {
+      const result = normalizeFilePath('README.md', projectRoot);
+      expect(result).toBe('README.md');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle paths with trailing spaces', () => {
+      const result = normalizeFilePath('  src/index.ts  ', projectRoot);
+      expect(result).toBe('src/index.ts');
+    });
+
+    it('should handle empty string', () => {
+      const result = normalizeFilePath('', projectRoot);
+      expect(result).toBe('');
+    });
+
+    it('should handle single space', () => {
+      const result = normalizeFilePath(' ', projectRoot);
+      expect(result).toBe('');
+    });
+
+    it('should handle paths with multiple slashes', () => {
+      const result = normalizeFilePath('src//components///Button.tsx', projectRoot);
+      // normalizeFilePath doesn't clean up multiple slashes, it just returns the path as-is
+      expect(result).toBe('src//components///Button.tsx');
+    });
+
+    it('should handle Windows-style paths on Unix', () => {
+      const windowsPath = 'src\\components\\Button.tsx';
+      const result = normalizeFilePath(windowsPath, projectRoot);
+      // On Unix, backslashes are treated as part of the filename
+      expect(result).toBe(windowsPath);
+    });
+  });
+
+  describe('with different project roots', () => {
+    it('should work with project root ending with slash', () => {
+      const rootWithSlash = '/Users/test/project/';
+      const result = normalizeFilePath('/Users/test/project/src/index.ts', rootWithSlash);
+      expect(result).toBe('src/index.ts');
+    });
+
+    it('should work with Windows-style project root', () => {
+      const windowsRoot = 'C:\\Users\\test\\project';
+      const windowsFile = 'C:\\Users\\test\\project\\src\\index.ts';
+      // This test will behave differently on Windows vs Unix
+      const result = normalizeFilePath(windowsFile, windowsRoot);
+      // Just check that it doesn't throw
+      expect(result).toBeDefined();
+    });
+  });
+});

--- a/mcp-server/src/tools/activity-logger/__tests__/tool.test.ts
+++ b/mcp-server/src/tools/activity-logger/__tests__/tool.test.ts
@@ -1,0 +1,252 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { activityLoggerTool, handleActivityLoggerTool } from '../tool.js';
+import { ActivityLogger } from '../index.js';
+import { createTestDatabase } from '../../../__tests__/utils/test-database.js';
+import Database from 'better-sqlite3';
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+
+// Store original console.error
+const originalConsoleError = console.error;
+
+describe('activityLoggerTool', () => {
+  it('should have correct tool definition', () => {
+    expect(activityLoggerTool.name).toBe('log_activity');
+    expect(activityLoggerTool.description).toContain('Log your AI-assisted development activities');
+    expect(activityLoggerTool.inputSchema.type).toBe('object');
+    expect(activityLoggerTool.inputSchema.required).toEqual(['activity', 'tool_name']);
+  });
+
+  it('should have all expected properties in schema', () => {
+    const properties = activityLoggerTool.inputSchema.properties;
+    expect(properties).toHaveProperty('activity');
+    expect(properties).toHaveProperty('tool_name');
+    expect(properties).toHaveProperty('success');
+    expect(properties).toHaveProperty('error');
+    expect(properties).toHaveProperty('tags');
+    expect(properties).toHaveProperty('context');
+    expect(properties).toHaveProperty('files_affected');
+    expect(properties).toHaveProperty('issue_number');
+    expect(properties).toHaveProperty('link');
+  });
+
+  it('should have correct property types', () => {
+    const properties = activityLoggerTool.inputSchema.properties;
+    expect(properties.activity.type).toBe('string');
+    expect(properties.tool_name.type).toBe('string');
+    expect(properties.success.type).toBe('boolean');
+    expect(properties.success.default).toBe(true);
+    expect(properties.error.type).toBe('string');
+    expect(properties.tags.type).toBe('array');
+    expect(properties.tags.items.type).toBe('string');
+    expect(properties.context.type).toBe('string');
+    expect(properties.files_affected.type).toBe('array');
+    expect(properties.files_affected.items.type).toBe('string');
+    expect(properties.issue_number.type).toBe('number');
+    expect(properties.link.type).toBe('string');
+  });
+});
+
+describe('handleActivityLoggerTool', () => {
+  let db: Database.Database;
+  let logger: ActivityLogger;
+  let consoleErrorSpy: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    db = createTestDatabase();
+    logger = new ActivityLogger('/test/project', db);
+    // Mock console.error
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    db.close();
+    // Restore console.error
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('should handle successful activity logging', async () => {
+    const args = {
+      activity: 'Created test file',
+      tool_name: 'test-tool',
+      tags: ['testing', 'setup'],
+      context: 'Setting up test environment'
+    };
+
+    const result = await handleActivityLoggerTool(args, logger);
+
+    expect(result).toBeDefined();
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0]).toMatchObject({
+      type: 'text',
+      text: expect.stringContaining('📋 Activity logged successfully')
+    });
+    expect(result.content[0].text).toMatch(/ID: \d+/);
+    expect(result.isError).toBeUndefined();
+  });
+
+  it('should handle activity with all parameters', async () => {
+    const args = {
+      activity: 'Fixed critical bug',
+      tool_name: 'bug-fixer',
+      success: false,
+      error: 'Partial fix applied',
+      tags: ['bug-fix', 'critical', 'authentication'],
+      context: 'Fixed login issue but needs more work',
+      files_affected: ['src/auth.ts', 'src/login.ts'],
+      issue_number: 42,
+      link: 'https://github.com/user/repo/issues/42'
+    };
+
+    const result = await handleActivityLoggerTool(args, logger);
+
+    expect(result.content[0].text).toContain('📋 Activity logged successfully');
+    
+    // Verify data was stored correctly
+    const activities = db.prepare('SELECT * FROM activity_log ORDER BY id DESC LIMIT 1').all() as any[];
+    expect(activities[0].activity).toBe('Fixed critical bug');
+    expect(activities[0].success).toBe(0);
+    expect(activities[0].error).toBe('Partial fix applied');
+  });
+
+  it('should handle database errors', async () => {
+    // Close database to simulate error
+    db.close();
+
+    const args = {
+      activity: 'Test activity',
+      tool_name: 'test'
+    };
+
+    const result = await handleActivityLoggerTool(args, logger);
+
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0].text).toContain('⚠️ CRITICAL ERROR');
+    expect(result.content[0].text).toContain('Failed to log activity');
+    expect(result.content[0].text).toContain('database connection is not open');
+    expect(result.isError).toBe(true);
+    
+    // Verify console.error was called (ActivityLogger logs the error and the tool handler logs it again)
+    expect(console.error).toHaveBeenCalled();
+    // Check that at least one call contains the error message
+    const errorCalls = consoleErrorSpy.mock.calls;
+    const hasExpectedError = errorCalls.some(call => 
+      call.some(arg => 
+        typeof arg === 'string' && arg.includes('database connection is not open')
+      )
+    );
+    expect(hasExpectedError).toBe(true);
+  });
+
+  it('should handle unexpected errors', async () => {
+    // Create a logger that will throw an unexpected error
+    const errorLogger = {
+      logActivity: () => {
+        throw new TypeError('Cannot read property of undefined');
+      }
+    } as any;
+
+    const args = {
+      activity: 'Test activity',
+      tool_name: 'test'
+    };
+
+    const result = await handleActivityLoggerTool(args, errorLogger);
+
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0].text).toContain('⚠️ CRITICAL ERROR');
+    expect(result.content[0].text).toContain('Unexpected error');
+    expect(result.content[0].text).toContain('Cannot read property of undefined');
+    expect(result.isError).toBe(true);
+  });
+
+  it('should handle missing required parameters gracefully', async () => {
+    // Although schema validation should catch this, test defensive coding
+    const args = {
+      activity: 'Test activity'
+      // missing tool_name
+    } as any;
+
+    const result = await handleActivityLoggerTool(args, logger);
+
+    // Should still attempt to log, database will handle the constraint
+    expect(result.content[0].text).toContain('CRITICAL ERROR');
+    expect(result.isError).toBe(true);
+  });
+
+  it('should handle various success parameter values', async () => {
+    const testCases = [
+      { input: { success: true }, expected: 1 },
+      { input: { success: false }, expected: 0 },
+      { input: { success: undefined }, expected: 1 }, // defaults to true
+      { input: {}, expected: 1 } // defaults to true when not provided
+    ];
+
+    for (const testCase of testCases) {
+      const args = {
+        activity: `Test with success: ${JSON.stringify(testCase.input.success)}`,
+        tool_name: 'test',
+        ...testCase.input
+      };
+
+      const result = await handleActivityLoggerTool(args, logger);
+      expect(result.content[0].text).toContain('📋 Activity logged successfully');
+      
+      // Verify in database
+      const row = db.prepare('SELECT success FROM activity_log WHERE activity = ?').get(args.activity) as any;
+      expect(row.success).toBe(testCase.expected);
+    }
+  });
+
+  it('should return correct result structure', async () => {
+    const args = {
+      activity: 'Test activity',
+      tool_name: 'test'
+    };
+
+    const result = await handleActivityLoggerTool(args, logger);
+
+    // Check CallToolResult structure
+    expect(result).toHaveProperty('content');
+    expect(Array.isArray(result.content)).toBe(true);
+    expect(result.content[0]).toHaveProperty('type');
+    expect(result.content[0]).toHaveProperty('text');
+    expect(result.content[0].type).toBe('text');
+  });
+
+  it('should handle very long activity descriptions', async () => {
+    const longActivity = 'A'.repeat(1000);
+    const args = {
+      activity: longActivity,
+      tool_name: 'test'
+    };
+
+    const result = await handleActivityLoggerTool(args, logger);
+
+    expect(result.content[0].text).toContain('📋 Activity logged successfully');
+    
+    // Verify it was stored
+    const row = db.prepare('SELECT activity FROM activity_log ORDER BY id DESC LIMIT 1').get() as any;
+    expect(row.activity).toBe(longActivity);
+  });
+
+  it('should handle special characters in strings', async () => {
+    const args = {
+      activity: "Created file with 'quotes' and \"double quotes\"",
+      tool_name: "test's tool",
+      context: 'Context with\nnewlines\tand\ttabs',
+      link: 'https://example.com?param=value&other=123'
+    };
+
+    const result = await handleActivityLoggerTool(args, logger);
+
+    expect(result.content[0].text).toContain('📋 Activity logged successfully');
+    
+    // Verify special characters were preserved
+    const row = db.prepare('SELECT * FROM activity_log ORDER BY id DESC LIMIT 1').get() as any;
+    expect(row.activity).toBe(args.activity);
+    expect(row.tool_name).toBe(args.tool_name);
+    expect(row.context).toBe(args.context);
+    expect(row.link).toBe(args.link);
+  });
+});


### PR DESCRIPTION
## Summary
- Implements optional GitHub Projects integration for idea capture and work queue management
- Adds configuration support for project status mappings
- Enhances existing prompts to integrate with GitHub Projects when enabled

## Implementation Details

### Configuration Enhancement
- Extended `GitHubConfig` interface with optional `github_projects` configuration
- Added `GitHubProjectsConfig` interface with status mappings and project ID

### New Components
- **`github_project.hbs`** partial - Reusable GitHub Projects operations
- **`create_idea.yaml`** prompt - Conversational idea capture as draft items

### Enhanced Prompts
- **`init_simone.yaml`** - Added project discovery and status mapping setup
- **`work_issue.yaml`** - Check project work queue when no issue provided
- **`create_issue.yaml`** - Add newly created issues to project

## Test Plan
- [ ] Test init_simone with GitHub Projects setup
- [ ] Test work queue integration in work_issue
- [ ] Test automatic project item creation in create_issue
- [ ] Test conversational idea capture with create_idea
- [ ] Verify prompts work correctly when Projects is disabled

Closes #59