### PR TITLE
fix: grant write permissions to Claude Code Review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,8 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
     
     steps:


### PR DESCRIPTION
The Claude Code Review workflow was failing with 'Resource not accessible by integration' error because it only had read permissions for pull requests.

This PR updates the permissions to include:
- pull-requests: write (required to post review comments)
- issues: write (required for issue operations)

This will fix the failing checks on PRs like #60.