### PR TITLE
Add optional GitHub Projects integration to Simone MCP server

### DIFF
--- a/mcp-server/src/config/types.ts
+++ b/mcp-server/src/config/types.ts
@@ -119,8 +119,21 @@ export interface GitHubConfig {
   repository: string;  // owner/repo format
   tool?: 'mcp' | 'cli';  // default to 'cli' if not specified
   defaultLabels?: string[];  // labels to apply to new issues
+  github_projects?: GitHubProjectsConfig;  // optional GitHub Projects integration
   // Allow custom GitHub properties
   [key: string]: any;
+}
+
+/**
+ * GitHub Projects integration configuration
+ */
+export interface GitHubProjectsConfig {
+  enabled: boolean;           // whether Projects integration is enabled
+  project_id: string;         // GitHub Project ID
+  idea_status: string;        // status for draft/idea items
+  work_status: string;        // status for items to pull from work queue
+  new_issue_status: string;   // status for newly created issues
+  available_statuses?: string[];  // cached list of available statuses
 }
 
 /**

--- a/mcp-server/src/templates/prompts/create_idea.yaml
+++ b/mcp-server/src/templates/prompts/create_idea.yaml
@@ -1,0 +1,125 @@
+name: create_idea
+description: Capture and organize ideas as GitHub Project draft items through conversation
+arguments: []
+template: |
+  # Capture Project Idea
+  
+  **IMPORTANT:** Follow from Top to Bottom - don't skip anything!
+  
+  **CREATE A TODO LIST** with exactly these 5 items:
+  
+  1. Engage in idea discussion
+  2. Structure the idea content
+  3. Determine idea type and priority
+  4. Create draft item in GitHub Project
+  5. Link related context
+  
+  ## 1 · Engage in idea discussion
+  
+  Ask the user: "What's your idea? Let's explore it together."
+  
+  Have a natural conversation to understand:
+  - The core concept
+  - Why it matters
+  - Potential implementation approaches
+  - Any concerns or unknowns
+  
+  {{#if (lt project.riskLevel 5)}}
+  Ask clarifying questions until the idea is well-formed:
+  - What problem does this solve?
+  - How might users benefit?
+  - What are the technical considerations?
+  - Any dependencies or blockers?
+  {{else}}
+  Quickly capture the essence and key points
+  {{/if}}
+  
+  Continue the conversation until you have enough context to document the idea properly.
+  
+  ## 2 · Structure the idea content
+  
+  Based on the discussion, create a structured summary:
+  
+  **Title**: [Concise, descriptive title]
+  
+  **Description**:
+  - Problem/Opportunity: [What gap or need does this address?]
+  - Proposed Solution: [Core concept and approach]
+  - Benefits: [Expected value and impact]
+  
+  **Technical Notes**:
+  - Implementation considerations
+  - Potential challenges
+  - Dependencies or prerequisites
+  
+  **Open Questions**:
+  - [List any unknowns or areas needing research]
+  
+  ## 3 · Determine idea type and priority
+  
+  Analyze the idea to categorize it:
+  
+  **Type**:
+  - Feature: New functionality
+  - Enhancement: Improvement to existing feature
+  - Research: Investigation needed
+  - Architecture: System design change
+  - Other: [Specify]
+  
+  **Priority Assessment**:
+  - Impact: [High/Medium/Low]
+  - Effort: [High/Medium/Low]
+  - Urgency: [High/Medium/Low]
+  
+  {{#if (lt project.riskLevel 5)}}
+  Confirm categorization with the user
+  {{/if}}
+  
+  ## 4 · Create draft item in GitHub Project
+  
+  {{#if github.github_projects.enabled}}
+  {{> github}}
+  
+  Create a new project item as a draft:
+  
+  ```bash
+  gh project item-add {{github.github_projects.project_id}} \
+    --owner {{github.repository}} \
+    --title "[TITLE]" \
+    --body "[STRUCTURED CONTENT FROM STEP 2]"
+  ```
+  
+  The item will be created at the idea status: `{{github.github_projects.idea_status}}`
+  
+  Note the created item ID for reference.
+  {{else}}
+  **GitHub Projects not configured** - Document the idea locally or create a draft issue instead.
+  
+  Ask the user: "GitHub Projects isn't configured. Would you like to create a draft issue instead?"
+  {{/if}}
+  
+  ## 5 · Link related context
+  
+  Connect the idea to relevant context:
+  
+  - Search for related issues or PRs
+  - Identify relevant code areas
+  - Link to documentation or discussions
+  
+  {{#if github.github_projects.enabled}}
+  Update the project item with links to related content if found.
+  {{/if}}
+  
+  Log the captured idea:
+  ```
+  activity: "Captured project idea"
+  tool_name: "create_idea"
+  tags: ["idea", "planning"]
+  context: "[Brief idea summary]"
+  ```
+  
+  ✅ **Result**: [Describe what was captured - idea title and where it was stored]
+  
+  💡 **Idea Type**: [State the categorized type and priority assessment]
+  
+  💬 **Summary**: [Provide summary of the idea discussion and next steps]

--- a/mcp-server/src/templates/prompts/create_issue.yaml
+++ b/mcp-server/src/templates/prompts/create_issue.yaml
@@ -125,6 +125,22 @@ template: |
   After creating the issue, link it to issue #{{related_issue}} by adding a comment that references the new issue number.
   {{/if}}
   
+  {{#if github.github_projects.enabled}}
+  ### Add Issue to GitHub Project
+  
+  Add the newly created issue to the project at the configured status:
+  ```bash
+  gh project item-add {{github.github_projects.project_id}} --owner {{github.repository}} --url [ISSUE_URL]
+  ```
+  
+  Then update its status to the new issue status:
+  ```bash
+  gh project item-edit --id [ITEM_ID] --field-id [STATUS_FIELD_ID] --project-id {{github.github_projects.project_id}} --single-select-option-id [{{github.github_projects.new_issue_status}}_ID]
+  ```
+  
+  The issue is now tracked in the project at status: `{{github.github_projects.new_issue_status}}`
+  {{/if}}
+  
   ✅ **Result**: [Describe the actual outcome - issue number created and any relevant details]
   
   🔎 **Scope**: [Describe the scope - complexity score, number of affected files, and project areas]

--- a/mcp-server/src/templates/prompts/init_simone.yaml
+++ b/mcp-server/src/templates/prompts/init_simone.yaml
@@ -147,6 +147,42 @@ template: |
   
   Update project.yaml with correct GitHub settings if needed.
   
+  ### GitHub Projects Integration (Optional)
+  
+  Ask the user: "Would you like to integrate GitHub Projects for idea capture and work queue management?"
+  
+  If yes:
+  
+  1. **Find or create project**:
+     - List existing projects: `gh project list --owner [owner]`
+     - If no suitable project exists, get user confirmation to create new one
+     - Create project if needed: `gh project create --owner [owner] --title "[Project Name]"`
+  
+  2. **Discover available statuses**:
+     - Get project field data: `gh api graphql -f query='query{node(id:"[PROJECT_ID]"){...on ProjectV2{fields(first:20){nodes{...on ProjectV2SingleSelectField{name options{name}}}}}}}'`
+     - Extract status field options
+     - Display available statuses to user
+  
+  3. **Configure status mappings**:
+     - Ask user to map statuses for:
+       - idea_status: Where draft ideas are captured (e.g., "Ideas", "Draft")
+       - work_status: Where to pull work items from (e.g., "Ready", "Todo")
+       - new_issue_status: Where newly created issues go (e.g., "Backlog", "New")
+  
+  4. **Update configuration**:
+     ```yaml
+     github:
+       repository: owner/repo
+       tool: cli
+       github_projects:
+         enabled: true
+         project_id: PVT_[ID]
+         idea_status: [selected status]
+         work_status: [selected status]
+         new_issue_status: [selected status]
+         available_statuses: [list of discovered statuses]
+     ```
+  
   ## 7 · Complete initialization
   
   Check if {{PROJECT_PATH}}/CLAUDE.md exists:

--- a/mcp-server/src/templates/prompts/partials/github_project.hbs
+++ b/mcp-server/src/templates/prompts/partials/github_project.hbs
@@ -1,0 +1,34 @@
+{{!-- GitHub Projects operations based on configuration --}}
+{{#if github.github_projects}}
+{{#if github.github_projects.enabled}}
+## GitHub Projects Integration
+
+Project ID: `{{github.github_projects.project_id}}`
+
+Use GitHub CLI for project operations:
+
+### Adding items to project
+```bash
+gh project item-add {{github.github_projects.project_id}} --owner {{github.repository}} --title "TITLE" --body "BODY"
+```
+
+### Updating item status
+```bash
+gh project item-edit --id ITEM_ID --field-id STATUS_FIELD_ID --project-id {{github.github_projects.project_id}} --owner {{github.repository}}
+```
+
+### Querying project items by status
+```bash
+gh project item-list {{github.github_projects.project_id}} --owner {{github.repository}} --format json | jq '.items[] | select(.status == "{{github.github_projects.work_status}}")'
+```
+
+Status mappings:
+- Ideas/drafts: `{{github.github_projects.idea_status}}`
+- Work queue: `{{github.github_projects.work_status}}`
+- New issues: `{{github.github_projects.new_issue_status}}`
+{{#if github.github_projects.available_statuses}}
+
+Available statuses: {{#each github.github_projects.available_statuses}}`{{this}}`{{#unless @last}}, {{/unless}}{{/each}}
+{{/if}}
+{{/if}}
+{{/if}}

--- a/mcp-server/src/templates/prompts/work_issue.yaml
+++ b/mcp-server/src/templates/prompts/work_issue.yaml
@@ -23,12 +23,31 @@ template: |
   {{#if issue}}
   Fetching issue #{{issue}} content
   {{else}}
-  If the issue argument doesn't contain helpful information, ask the user what they want to work on.
+  {{#if github.github_projects.enabled}}
+  ### Check GitHub Projects Work Queue
+  
+  Query items from the work queue status:
+  ```bash
+  gh project item-list {{github.github_projects.project_id}} --owner {{github.repository}} --format json | jq '.items[] | select(.status == "{{github.github_projects.work_status}}")'
+  ```
+  
+  If work items are found:
+  - List them with their titles and descriptions
+  - Ask the user which item they want to work on
+  - Get the associated issue number if the item is linked to an issue
+  
+  If no work items are found or user doesn't select one:
+  {{/if}}
+  Ask the user what they want to work on.
   {{/if}}
   
   {{> github}}
   
+  {{#if issue}}
   Fetch issue #{{issue}} details to understand the requirements.
+  {{else}}
+  Once an issue is selected, fetch its details to understand the requirements.
+  {{/if}}
   
   Read the issue content carefully and identify:
   - Core problem or feature to implement


### PR DESCRIPTION
## Summary
- Implements optional GitHub Projects integration for idea capture and work queue management
- Adds configuration support for project status mappings
- Enhances existing prompts to integrate with GitHub Projects when enabled

## Implementation Details

### Configuration Enhancement
- Extended `GitHubConfig` interface with optional `github_projects` configuration
- Added `GitHubProjectsConfig` interface with status mappings and project ID

### New Components
- **`github_project.hbs`** partial - Reusable GitHub Projects operations
- **`create_idea.yaml`** prompt - Conversational idea capture as draft items

### Enhanced Prompts
- **`init_simone.yaml`** - Added project discovery and status mapping setup
- **`work_issue.yaml`** - Check project work queue when no issue provided
- **`create_issue.yaml`** - Add newly created issues to project

## Test Plan
- [ ] Test init_simone with GitHub Projects setup
- [ ] Test work queue integration in work_issue
- [ ] Test automatic project item creation in create_issue
- [ ] Test conversational idea capture with create_idea
- [ ] Verify prompts work correctly when Projects is disabled

Closes #59