### PR TITLE
fix: update activity logger tests for console.error → logError change

### DIFF
--- a/mcp-server/src/tools/activity-logger/index.test.ts
+++ b/mcp-server/src/tools/activity-logger/index.test.ts
@@ -12,9 +12,14 @@ vi.mock('./path-normalizer.js', () => ({
   normalizeFilePath: vi.fn(),
 }));
 
+vi.mock('../../utils/logger.js', () => ({
+  logError: vi.fn(),
+}));
+
 // Import mocked modules
 import { detectActivityType } from './activity-types.js';
 import { normalizeFilePath } from './path-normalizer.js';
+import { logError } from '../../utils/logger.js';
 
 describe('ActivityLogger', () => {
   mockConsoleLog();
@@ -245,9 +250,10 @@ describe('ActivityLogger', () => {
         error: 'Database error',
       });
       
-      expect(console.error).toHaveBeenCalledWith(
-        expect.stringContaining('[ActivityLogger.logActivity] Database operation failed'),
-        expect.any(Error)
+      expect(logError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining('[ActivityLogger.logActivity] Database operation failed')
+        })
       );
     });
 

--- a/mcp-server/src/tools/activity-logger/tool.test.ts
+++ b/mcp-server/src/tools/activity-logger/tool.test.ts
@@ -2,6 +2,13 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { handleActivityLoggerTool, activityLoggerTool } from './tool.js';
 import { mockConsoleLog } from '../../__tests__/utils/index.js';
 
+// Mock the logger module
+vi.mock('../../utils/logger.js', () => ({
+  logError: vi.fn(),
+}));
+
+import { logError } from '../../utils/logger.js';
+
 describe('ActivityLoggerTool', () => {
   mockConsoleLog();
 
@@ -109,8 +116,10 @@ describe('ActivityLoggerTool', () => {
         mockLogger
       );
       
-      expect(console.error).toHaveBeenCalledWith(
-        '[ACTIVITY LOGGER ERROR] Failed to log activity: Database connection failed'
+      expect(logError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: '[ACTIVITY LOGGER ERROR] Failed to log activity: Database connection failed'
+        })
       );
       
       expect(result).toEqual({
@@ -139,8 +148,10 @@ describe('ActivityLoggerTool', () => {
         mockLogger
       );
       
-      expect(console.error).toHaveBeenCalledWith(
-        '[ACTIVITY LOGGER ERROR] Unexpected error: Unexpected error'
+      expect(logError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: '[ACTIVITY LOGGER ERROR] Unexpected error: Unexpected error'
+        })
       );
       
       expect(result).toEqual({
@@ -169,8 +180,10 @@ describe('ActivityLoggerTool', () => {
         mockLogger
       );
       
-      expect(console.error).toHaveBeenCalledWith(
-        '[ACTIVITY LOGGER ERROR] Unexpected error: String error'
+      expect(logError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: '[ACTIVITY LOGGER ERROR] Unexpected error: String error'
+        })
       );
       
       expect(result.isError).toBe(true);


### PR DESCRIPTION
## Summary
- Updates test expectations to match the implementation changes from PR #66
- Mocks the logError function from utils/logger
- Fixes all 4 failing tests in activity logger test suites

## Context
PR #66 replaced console.error calls with logError utility, but the tests were still expecting console.error to be called. This PR updates the tests to match the new implementation.

## Test Plan
- [x] Run `pnpm test` - all tests should pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated tests to verify error logging using a new logging utility instead of direct console error calls. No changes to test logic or outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->