### PR TITLE
fix(mcp): Built-in partials not available in user custom prompts

### DIFF
--- a/mcp-server/src/templates/loader.test.ts
+++ b/mcp-server/src/templates/loader.test.ts
@@ -233,6 +233,13 @@ describe('TemplateLoader', () => {
 
     it('should rate limit partial checking', async () => {
       vi.mocked(fsPromises.readdir).mockResolvedValue([] as any);
+      // Mock existsSync to return true for the first built-in path
+      vi.mocked(fs.existsSync).mockImplementation((path) => {
+        if (typeof path === 'string' && path.includes('prompts/partials')) {
+          return true;
+        }
+        return false;
+      });
       
       // First compile - should check partials
       await loader.compileTemplate('Test 1');


### PR DESCRIPTION
## Summary
- Fixed built-in partial directory resolution to work in both development and production environments
- Added multiple path checking to find partials at correct locations
- Ensured user partials properly override built-in ones

Closes #74

## Changes Made

### Path Resolution Fix
Modified `TemplateLoader` class in `src/templates/loader.ts` to check multiple paths when loading built-in partials:
- Production: `dist/prompts/partials/`  
- Development: `src/templates/prompts/partials/`

This ensures built-in partials are found regardless of whether the MCP server is running from source or as an installed npm package.

### Loading Order
- Built-in partials are loaded first as defaults
- User partials then override any built-in partials with the same name
- Proper error logging if built-in partials directory is not found

### Test Updates
Updated the rate limiting test to properly mock `existsSync` for the new path checking logic.

## Testing Performed

1. ✅ All existing tests pass
2. ✅ Created test custom prompt using built-in partials
3. ✅ Verified partials load correctly in development environment
4. ✅ Build process completes successfully
5. ✅ No breaking changes to existing functionality

## Edge Cases Considered

- Running from development environment (tsx/ts-node)
- Running from production (installed via npm)
- User partials with same names as built-in partials
- Missing partials directories
- Rate limiting for partial checking

## Review Notes

The fix uses a simple multiple-path checking approach that tries known locations for built-in partials. This maintains backward compatibility while fixing the issue for installed packages.