### PR TITLE
fix(mcp): add missing Handlebars logical helpers (or, and, not)

### DIFF
--- a/mcp-server/src/templates/helpers/index.ts
+++ b/mcp-server/src/templates/helpers/index.ts
@@ -30,4 +30,21 @@ export function registerHelpers(): void {
   Handlebars.registerHelper('gte', function(a: any, b: any) {
     return a >= b;
   });
+  
+  // Register logical helpers
+  Handlebars.registerHelper('or', function(...args: any[]) {
+    // Remove the options hash from arguments
+    args.pop(); // Remove options hash
+    return args.some(arg => !!arg);
+  });
+  
+  Handlebars.registerHelper('and', function(...args: any[]) {
+    // Remove the options hash from arguments
+    args.pop(); // Remove options hash
+    return args.every(arg => !!arg);
+  });
+  
+  Handlebars.registerHelper('not', function(value: any) {
+    return !value;
+  });
 }


### PR DESCRIPTION
## Summary

Closes #78

This PR fixes a template rendering error in the `check_activity` command by registering the missing Handlebars logical helpers.

## Changes Made

- Added `or` helper to support logical OR operations in templates
- Added `and` helper for logical AND operations  
- Added `not` helper for negation operations

The error occurred because the `check_activity.yaml` template uses `{{#if (or (eq period "7d") (eq period "30d"))}}` but the `or` helper wasn't registered in the Handlebars configuration.

## Testing Performed

- ✅ All existing tests pass (`pnpm test`)
- ✅ Build succeeds without errors (`pnpm build`)
- ✅ Linter passes (with pre-existing warnings unrelated to this change)
- ✅ The logical helpers follow standard Handlebars patterns

## Edge Cases Considered

- Helpers properly handle multiple arguments
- Options hash is correctly removed from arguments array
- Helpers are registered during template initialization

## Technical Details

The helpers use standard JavaScript array methods:
- `or`: Uses `Array.some()` to return true if any argument is truthy
- `and`: Uses `Array.every()` to return true if all arguments are truthy  
- `not`: Simple negation of the input value

These are commonly expected helpers in Handlebars templates and their implementation follows established patterns from the Handlebars community.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added logical operators for templates: and, or, not, enabling richer conditional rendering without verbose nesting.
  * and/or accept multiple conditions, evaluating them collectively for cleaner, more maintainable templates.
  * Improves flexibility when showing/hiding sections or switching content based on multiple flags or states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->