### PR TITLE
fix: bump simone-mcp version to 0.4.0

### DIFF
--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simone-mcp",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "MCP server for Simone - AI-powered project and task management",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Quick fix to bump the version in mcp-server/package.json to 0.4.0 for npm release. The changelog was already updated in PR #83.